### PR TITLE
fix(npmignore): Fix npmignore to keep the documentation cli

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,7 @@
 .npmrc
 .sass-cache
 .travis.yml
-documentation
+documentation/www
 npm-debug.log
 tests
 example


### PR DESCRIPTION
As the package.json expose the documentation cli, the install process of ParaViewWeb will fail as the full documentation was ignored. Bringing back the tool and ignoring only the ./documentation/www directory.