### PR TITLE
Update license reference text

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ npm run build
 
 ### Licensing
 
-**ParaViewWeb** is licensed under [BSD Clause 3](LICENSE).
+**ParaViewWeb** is licensed under the [BSD 3-Clause License](LICENSE).
 
 ### Getting Involved
 


### PR DESCRIPTION
The text "BSD Clause 3" is a bit wrong - sounds like it is only BSD's third clause.

Changing to what seems to be the more official name from

https://opensource.org/licenses/BSD-3-Clause