### PR TITLE
fix(Ansible): Replace include_vars with copy of vars

### DIFF
--- a/tools/ansible/roles/apache/vars/RedHat.yml
+++ b/tools/ansible/roles/apache/vars/RedHat.yml
@@ -1,1 +1,3 @@
-- include_vars: ./CentOS.yml
+apache_package_name: httpd
+apache_service_name: httpd
+apache_user_name: apache

--- a/tools/ansible/roles/paraview/vars/RedHat.yml
+++ b/tools/ansible/roles/paraview/vars/RedHat.yml
@@ -1,1 +1,6 @@
-- include_vars: ./CentOS.yml
+packages:
+  - xorg-x11-server-Xorg
+  - "@^gnome-desktop-environment"
+  - mesa-libGL-devel
+  - libXt-devel
+  - libatomic


### PR DESCRIPTION
Unfortunately include_vars can't be nested in a variable file. So replace with a copy of the vars.