### PR TITLE
fix(Widgets): Guard against undefined 'to' property

### DIFF
--- a/src/React/Widgets/GitTreeWidget/index.js
+++ b/src/React/Widgets/GitTreeWidget/index.js
@@ -86,7 +86,7 @@ function extractBranchesAndForks(model, leaf) {
   }
 
   // Do we really have a new branch?
-  if (branch.to !== branch.y) {
+  if (typeof branch.to !== 'undefined' && branch.to !== branch.y) {
     branches.push(branch);
   }
 


### PR DESCRIPTION
A single node with without a 'to' property was being treated as a
branch, which was then causing a NAN error when rendering a SVG
path.