### PR TITLE
fix(IO): Allow retry behaviour to be configured

### DIFF
--- a/src/IO/WebSocket/AutobahnConnection/index.js
+++ b/src/IO/WebSocket/AutobahnConnection/index.js
@@ -25,10 +25,12 @@ function getTransportObject(url) {
 }
 
 export default class AutobahnConnection {
-  constructor(urls, secret = 'vtkweb-secret') {
+  constructor(urls, secret = 'vtkweb-secret', retry = false) {
     this.urls = urls;
     this.secret = secret;
     this.connection = null;
+    // Should autobahn try to reconnect on error?
+    this.retry = retry;
   }
 
   connect() {
@@ -70,7 +72,7 @@ export default class AutobahnConnection {
     this.connection.onclose = () => {
       this.emit(CONNECTION_CLOSE_TOPIC, this);
       this.connection = null;
-      return true; // true => Stop retry
+      return !this.retry; // true => Stop retry
     };
 
     this.connection.open();

--- a/src/IO/WebSocket/SmartConnect/index.js
+++ b/src/IO/WebSocket/SmartConnect/index.js
@@ -12,7 +12,7 @@ const
 
 
 function autobahnConnect(self) {
-  var wsConnection = new AutobahnConnection(self.config.sessionURL, self.config.secret);
+  var wsConnection = new AutobahnConnection(self.config.sessionURL, self.config.secret, self.config.retry);
   self.subscriptions.push(wsConnection.onConnectionReady(self.readyForwarder));
   self.subscriptions.push(wsConnection.onConnectionClose(self.closeForwarder));
   wsConnection.connect();


### PR DESCRIPTION
Allow the Autobahn retry behaviour to be controlled by passing in a 'retry' property. The default behaviour is not to retry.