### PR TITLE
fix(loaders): Fix loader rule used by other projects

### DIFF
--- a/config/webpack.loaders.js
+++ b/config/webpack.loaders.js
@@ -30,7 +30,7 @@ module.exports = [
     loader: 'html-loader',
   }, {
     test: /\.js$/,
-    include: /node_modules\/|\\paraviewweb\/|\\/,
+    include: /node_modules(\/|\\)paraviewweb(\/|\\)/,
     loader: 'babel?presets[]=es2015,presets[]=react',
   }, {
     test: /\.js$/,


### PR DESCRIPTION
Fix broken loader rule which caused everything matching either
node_modules or paraviewweb to be run through babel, instead of
only things matching node_modules/paraviewweb/.