### PR TITLE
Histogram Selector scoring communicates partitions with a PartitionProvider

### DIFF
--- a/src/InfoViz/Core/PartitionProvider/index.js
+++ b/src/InfoViz/Core/PartitionProvider/index.js
@@ -1,0 +1,84 @@
+import CompositeClosureHelper from '../../../Common/Core/CompositeClosureHelper';
+
+// ----------------------------------------------------------------------------
+// Partition Provider
+// ----------------------------------------------------------------------------
+
+function partitionProvider(publicAPI, model, fetchHelper) {
+  // Private members
+  const ready = publicAPI.firePartitionReady;
+  delete publicAPI.firePartitionReady;
+
+  // Protected members
+  if (!model.partitionData) {
+    model.partitionData = {};
+  }
+
+  // Return true if data is available
+  publicAPI.loadPartition = field => {
+    if (!model.partitionData[field]) {
+      model.partitionData[field] = { pending: true };
+      fetchHelper.addRequest(field);
+      return false;
+    }
+
+    if (model.partitionData[field].pending) {
+      return false;
+    }
+
+    if (model.partitionData[field].stale) {
+      // stale means the client sent some data to the server,
+      // and we need the server to return 'ground truth', even
+      // though we have our version of the data right now.
+      delete model.partitionData[field].stale;
+      fetchHelper.addRequest(field);
+      return true;
+    }
+
+    return true;
+  };
+
+  publicAPI.getPartition = field => model.partitionData[field];
+  // server sent us some data
+  publicAPI.setPartition = (field, data) => {
+    model.partitionData[field] = data;
+    ready(field, data);
+  };
+  // client generated new data
+  publicAPI.changePartition = (field, data) => {
+    model.partitionData[field] = data;
+    model.partitionData[field].stale = true;
+    publicAPI.firePartitionChange(field, data);
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  // partitionData: null,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  CompositeClosureHelper.destroy(publicAPI, model);
+  CompositeClosureHelper.isA(publicAPI, model, 'PartitionProvider');
+  // Change asynchronous default - immediate event tiggers data send to server, and server reply is async.
+  CompositeClosureHelper.event(publicAPI, model, 'partitionChange', false);
+  CompositeClosureHelper.event(publicAPI, model, 'partitionReady');
+  const fetchHelper = CompositeClosureHelper.fetch(publicAPI, model, 'Partition');
+
+  partitionProvider(publicAPI, model, fetchHelper);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = CompositeClosureHelper.newInstance(extend);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };

--- a/src/InfoViz/Native/HistogramSelector/example/index.js
+++ b/src/InfoViz/Native/HistogramSelector/example/index.js
@@ -8,6 +8,7 @@ import FieldSelector from '../../../Native/FieldSelector';
 import CompositeClosureHelper from '../../../../../src/Common/Core/CompositeClosureHelper';
 import FieldProvider from '../../../../../src/InfoViz/Core/FieldProvider';
 import LegendProvider from '../../../../../src/InfoViz/Core/LegendProvider';
+import PartitionProvider from '../../../../../src/InfoViz/Core/PartitionProvider';
 import Histogram1DProvider from '../../../../../src/InfoViz/Core/Histogram1DProvider';
 
 import dataModel from './state.json';
@@ -36,6 +37,7 @@ const provider = CompositeClosureHelper.newInstance((publicAPI, model, initialVa
   FieldProvider.extend(publicAPI, model, initialValues);
   Histogram1DProvider.extend(publicAPI, model, initialValues);
   LegendProvider.extend(publicAPI, model, initialValues);
+  PartitionProvider.extend(publicAPI, model, initialValues);
 })(dataModel);
 
 // set provider behaviors
@@ -50,9 +52,9 @@ const histogramSelector = HistogramSelector.newInstance({
   provider,
   container: histogramSelectorContainer,
   // activate scoring gui
-  scores: [{ name: 'Yes', color: '#00C900' },
-           { name: 'Maybe', color: '#FFFF00' },
-           { name: 'No', color: '#C90000' },
+  scores: [{ name: 'Yes', color: '#00C900', value: 1 },
+           { name: 'Maybe', color: '#FFFF00', value: 0 },
+           { name: 'No', color: '#C90000', value: -1 },
           ],
   defaultScore: 1,
 });

--- a/src/InfoViz/Native/HistogramSelector/index.js
+++ b/src/InfoViz/Native/HistogramSelector/index.js
@@ -86,12 +86,8 @@ function histogramSelector(publicAPI, model) {
     ;
   }
 
-  function svgWidth() {
-    return model.histWidth + model.histMargin.left + model.histMargin.right;
-  }
-  function svgHeight() {
-    return model.histHeight + model.histMargin.top + model.histMargin.bottom;
-  }
+  publicAPI.svgWidth = () => (model.histWidth + model.histMargin.left + model.histMargin.right);
+  publicAPI.svgHeight = () => (model.histHeight + model.histMargin.top + model.histMargin.bottom);
 
   function fetchData() {
     model.needData = true;
@@ -246,9 +242,6 @@ function histogramSelector(publicAPI, model) {
       // number of boxesPerRow
       const mungedData = fieldNames.map(name => {
         const d = model.provider.getField(name);
-        if (typeof d.selectedGen === 'undefined') {
-          d.selectedGen = 0;
-        }
         return d;
       });
 
@@ -342,8 +335,7 @@ function histogramSelector(publicAPI, model) {
       // d3's listener method cannot guarantee the index passed to
       // updateData will be correct:
       function updateData(data) {
-        // data.selected = this.checked;
-        data.selectedGen++;
+        // data.selectedGen++;
         // model.provider.updateField(data.name, { active: data.selected });
         model.provider.toggleFieldSelection(data.name);
       }
@@ -424,11 +416,12 @@ function histogramSelector(publicAPI, model) {
 
       // adjust some settings based on current size
       tdsl.select('svg')
-        .attr('width', svgWidth())
-        .attr('height', svgHeight());
+        .attr('width', publicAPI.svgWidth())
+        .attr('height', publicAPI.svgHeight());
 
       // get the histogram data and rebuild the histogram based on the results
       const hobj = model.provider.getHistogram1D(def.name);
+      def.hobj = hobj;
       if (hobj !== null) {
         const cmax = 1.0 * d3.max(hobj.counts);
         const hsize = hobj.counts.length;
@@ -517,7 +510,7 @@ function histogramSelector(publicAPI, model) {
         gAxis.selectAll('line').classed(style.axisLine, true);
         gAxis.selectAll('path').classed(style.axisPath, true);
 
-        Score.prepareItem(def, idx, svgGr, hobj, tdsl);
+        Score.prepareItem(def, idx, svgGr, tdsl);
       }
     }
 
@@ -567,6 +560,8 @@ function histogramSelector(publicAPI, model) {
   model.subscriptions.push(model.provider.onFieldChange(fetchData));
   // event from Histogram Provider
   model.subscriptions.push(model.provider.onHistogram1DReady(publicAPI.render));
+  // scoring interface
+  Score.addSubscriptions();
 
   // Make sure default values get applied
   publicAPI.setContainer(model.container);
@@ -593,7 +588,7 @@ const DEFAULT_VALUES = {
   singleMode: false,
   scrollToName: null,
   // margins inside the SVG element.
-  histMargin: { top: 3, right: 3, bottom: 18, left: 3 },
+  histMargin: { top: 8, right: 8, bottom: 23, left: 8 },
   histWidth: 90,
   histHeight: 70,
   lastOffset: -1,


### PR DESCRIPTION
@jourdain @scottwittenburg Here's the working communication flow. I still needed a .scoreDirty flag so I could make temporary changes to dividers in the client (like dragging or typing in the popups) before I sent them to the server. This then meant I needed the PartitionProvider: partitionChange event to be synchronous, so it always happens before publicAPI.render() and getScores() is called. 

I am planning to squash and re-write commit messages, if it's OK overall. 