### PR TITLE
fix(HistogramSelector): Use the HistogramBinHoverProvider

### DIFF
--- a/src/InfoViz/Native/FieldSelector/index.js
+++ b/src/InfoViz/Native/FieldSelector/index.js
@@ -203,7 +203,7 @@ function fieldSelector(publicAPI, model) {
               hdata.enter().append('rect');
               // changes apply to both enter and update data join:
               hdata
-                .classed(style.histRect, true)
+                .attr('class', (d, i) => (i % 2 === 0 ? style.histRectEven : style.histRectOdd))
                 .attr('pname', fieldName)
                 .attr('y', d => model.fieldHistHeight * (1.0 - d / cmax))
                 .attr('x', (d, i) => (model.fieldHistWidth / hsize) * i)

--- a/src/InfoViz/Native/HistogramSelector/example/index.js
+++ b/src/InfoViz/Native/HistogramSelector/example/index.js
@@ -10,6 +10,7 @@ import FieldProvider from '../../../../../src/InfoViz/Core/FieldProvider';
 import LegendProvider from '../../../../../src/InfoViz/Core/LegendProvider';
 import PartitionProvider from '../../../../../src/InfoViz/Core/PartitionProvider';
 import Histogram1DProvider from '../../../../../src/InfoViz/Core/Histogram1DProvider';
+import HistogramBinHoverProvider from '../../../../../src/InfoViz/Core/HistogramBinHoverProvider';
 
 import dataModel from './state.json';
 
@@ -36,6 +37,7 @@ const provider = CompositeClosureHelper.newInstance((publicAPI, model, initialVa
   Object.assign(model, initialValues);
   FieldProvider.extend(publicAPI, model, initialValues);
   Histogram1DProvider.extend(publicAPI, model, initialValues);
+  HistogramBinHoverProvider.extend(publicAPI, model);
   LegendProvider.extend(publicAPI, model, initialValues);
   PartitionProvider.extend(publicAPI, model, initialValues);
 })(dataModel);

--- a/src/InfoViz/Native/ParallelCoordinates/example/index.js
+++ b/src/InfoViz/Native/ParallelCoordinates/example/index.js
@@ -1,5 +1,7 @@
 import 'normalize.css';
 
+import sizeHelper   from '../../../../Common/Misc/SizeHelper';
+
 import ParallelCoordinates from '../../../Native/ParallelCoordinates';
 import FieldSelector from '../../../Native/FieldSelector';
 
@@ -9,6 +11,7 @@ import Histogram1DProvider from '../../../../../src/InfoViz/Core/Histogram1DProv
 import Histogram2DProvider from '../../../../../src/InfoViz/Core/Histogram2DProvider';
 import LegendProvider from '../../../../../src/InfoViz/Core/LegendProvider';
 import MutualInformationProvider from '../../../../../src/InfoViz/Core/MutualInformationProvider';
+import HistogramBinHoverProvider from '../../../../../src/InfoViz/Core/HistogramBinHoverProvider';
 
 import dataModel from './state.json';
 
@@ -16,14 +19,14 @@ const bodyElt = document.querySelector('body');
 
 const parallelCoordinatesContainer = document.createElement('div');
 parallelCoordinatesContainer.style.position = 'relative';
-parallelCoordinatesContainer.style.width = '45%';
+parallelCoordinatesContainer.style.width = '60%';
 parallelCoordinatesContainer.style.height = '250px';
 parallelCoordinatesContainer.style.float = 'left';
 bodyElt.appendChild(parallelCoordinatesContainer);
 
 const fieldSelectorContainer = document.createElement('div');
 fieldSelectorContainer.style.position = 'relative';
-fieldSelectorContainer.style.width = '45%';
+fieldSelectorContainer.style.width = '40%';
 fieldSelectorContainer.style.height = '250px';
 fieldSelectorContainer.style.float = 'left';
 bodyElt.appendChild(fieldSelectorContainer);
@@ -33,16 +36,22 @@ const provider = CompositeClosureHelper.newInstance((publicAPI, model, initialVa
   FieldProvider.extend(publicAPI, model, initialValues);
   Histogram1DProvider.extend(publicAPI, model, initialValues);
   Histogram2DProvider.extend(publicAPI, model, initialValues);
+  HistogramBinHoverProvider.extend(publicAPI, model);
   LegendProvider.extend(publicAPI, model, initialValues);
   MutualInformationProvider.extend(publicAPI, model, initialValues);
 })(dataModel);
 
 // Create parallel coordinates
 const parallelCoordinates = ParallelCoordinates.newInstance({ provider, container: parallelCoordinatesContainer });
-parallelCoordinates.resize();
-parallelCoordinates.render();
 
 // Create field selector
 const fieldSelector = FieldSelector.newInstance({ provider, container: fieldSelectorContainer });
-fieldSelector.resize();
-fieldSelector.render();
+
+// Listen to window resize
+sizeHelper.onSizeChange(() => {
+  parallelCoordinates.resize();
+  fieldSelector.resize();
+});
+sizeHelper.startListening();
+
+sizeHelper.triggerChange();

--- a/src/InfoViz/Native/ParallelCoordinates/example/state.json
+++ b/src/InfoViz/Native/ParallelCoordinates/example/state.json
@@ -31,6 +31,38 @@
       "name": "free throw percent"
     }
   },
+  "histogram1DData": {
+    "percentage of team minutes": {
+      "max": 79.5,
+      "counts": [4, 11, 18, 24, 21, 23, 17, 16, 19, 17, 22, 14, 15, 20, 23, 18, 9, 13, 12, 14, 12, 15, 20, 16, 15, 20, 20, 13, 16, 13, 4, 6],
+      "name": "percentage of team minutes",
+      "min": 7.2
+    },
+    "percentage of team assists": {
+      "max": 49.2,
+      "counts": [18, 12, 37, 55, 47, 61, 34, 41, 26, 20, 18, 21, 12, 8, 17, 6, 9, 12, 5, 9, 7, 6, 8, 0, 2, 1, 4, 1, 0, 1, 0, 2],
+      "name": "percentage of team assists",
+      "min": 0.0
+    },
+    "steals per game": {
+      "max": 2.48,
+      "counts": [26, 26, 33, 27, 51, 32, 51, 30, 34, 31, 25, 22, 24, 16, 9, 13, 10, 7, 4, 6, 6, 5, 3, 3, 3, 1, 0, 0, 0, 1, 0, 1],
+      "name": "steals per game",
+      "min": 0.0
+    },
+    "minutes": {
+      "max": 38.5,
+      "counts": [14, 22, 20, 26, 20, 15, 14, 15, 19, 21, 19, 12, 15, 27, 19, 11, 9, 8, 18, 12, 16, 16, 13, 15, 15, 23, 16, 12, 16, 13, 3, 6],
+      "name": "minutes",
+      "min": 5.1000000000000005
+    },
+    "free throw percent": {
+      "max": 1.0,
+      "counts": [18, 0, 0, 0, 0, 1, 1, 0, 2, 0, 3, 1, 3, 4, 2, 3, 21, 11, 20, 13, 32, 31, 32, 37, 61, 58, 62, 37, 17, 7, 7, 16],
+      "name": "free throw percent",
+      "min": 0.0
+    }
+  },
   "histogram2DData": {
     "versatility index": {
       "rebounds pergame": {

--- a/style/InfoVizNative/FieldSelector.mcss
+++ b/style/InfoVizNative/FieldSelector.mcss
@@ -84,16 +84,22 @@
 
 .histRect {
   composes: jsHistRect;
-  fill: #7D86B3;
-  stroke: #7D86B3;
-  stroke-width: 0.25px;
+  stroke: none;
+  shape-rendering: crispEdges;
+}
+.histRectEven {
+  composes: histRect;
+  fill: #8089B8;
+}
+.histRectOdd {
+  composes: histRect;
+  fill: #7780AB;
 }
 
 .histoHilite {
   fill: #999;
-  stroke: #000;
 }
 
 .binHilite {
-  fill: blue;
+  fill: #001EB8;
 }

--- a/style/InfoVizNative/HistogramSelector.mcss
+++ b/style/InfoVizNative/HistogramSelector.mcss
@@ -286,6 +286,11 @@
   pointer-events: all;
 }
 
+.binHilite {
+  fill: #001EB8;
+}
+
+/* Scoring gui */
 .score {
   composes: jsScore;
   stroke: #fff;


### PR DESCRIPTION
@scottwittenburg Hover! And more hover!

Add handling for highlighting histogram bins that are hovered
with the mouse, and accept hover events from other components.
Don't generate hover events when editing the partition score,
however - it's too distracting. Clear the hover when editing starts.

Add the HistogramBinHoverProvider to the ParallelCoords example,
and update FieldSelector histogram bin styles to match the
HistogramSelector.