### PR TITLE
fix(ScoresProvider): get default score from score list

### DIFF
--- a/src/InfoViz/Core/ScoresProvider/index.js
+++ b/src/InfoViz/Core/ScoresProvider/index.js
@@ -24,6 +24,15 @@ function scoresProvider(publicAPI, model) {
     const score = model.scoreMapByValue[value];
     return score ? score.name : undefined;
   };
+  publicAPI.getDefaultScore = () => {
+    return model.scores ? model.scores.findIndex(score => !!score.isDefault) : 0;
+  };
+  publicAPI.setDefaultScore = value => {
+    if (model.scores) {
+      model.scores[publicAPI.getDefaultScore()].isDefault = false;
+      model.scores[value].isDefault = true;
+    }
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -31,7 +40,6 @@ function scoresProvider(publicAPI, model) {
 // ----------------------------------------------------------------------------
 
 const DEFAULT_VALUES = {
-  defaultScore: 0,
   // scores: null,
 };
 
@@ -43,8 +51,7 @@ export function extend(publicAPI, model, initialValues = {}) {
   CompositeClosureHelper.destroy(publicAPI, model);
   CompositeClosureHelper.isA(publicAPI, model, 'ScoresProvider');
   CompositeClosureHelper.event(publicAPI, model, 'scoresChange', false);
-  CompositeClosureHelper.get(publicAPI, model, ['defaultScore', 'scores']);
-  CompositeClosureHelper.set(publicAPI, model, ['defaultScore']);
+  CompositeClosureHelper.get(publicAPI, model, ['scores']);
 
   scoresProvider(publicAPI, model);
 }

--- a/src/InfoViz/Native/HistogramSelector/score.js
+++ b/src/InfoViz/Native/HistogramSelector/score.js
@@ -772,6 +772,11 @@ export default function init(inPublicAPI, inModel) {
             state[def.name] = [-1];
             model.provider.setHoverState({ state });
           }
+          // set existing annotation as current if we activate for editing
+          if (def.editScore && showScore(def) && def.annotation) {
+            // TODO special 'active' method to call, instead of an edit?
+            sendScores(def, def.hobj);
+          }
           publicAPI.render();
           return;
         }


### PR DESCRIPTION
The default score should have an 'isDefault' member, to
match ers server behavior. Don't store the default
separately.

Also make HistogramSelector trigger an annotation edit
when a partition selection is opened for editing, to
make it the 'active' annotation.

@scottwittenburg @jourdain this ok with what you are doing?