### PR TITLE
Histogram legend interaction, single view API

### DIFF
--- a/src/InfoViz/Native/HistogramSelector/example/index.js
+++ b/src/InfoViz/Native/HistogramSelector/example/index.js
@@ -70,6 +70,10 @@ const histogramSelector = HistogramSelector.newInstance({
 });
 // set a target number per row.
 histogramSelector.requestNumBoxesPerRow(4);
+// Or show a single variable as the focus.
+histogramSelector.displaySingleHistogram(provider.getFieldNames()[1]);
+// and maybe set a scoring annotation:
+// histogramSelector.setDefaultScorePartition(provider.getFieldNames()[1]);
 
 // Create field selector
 const fieldSelector = FieldSelector.newInstance({ provider, container: fieldSelectorContainer });

--- a/src/InfoViz/Native/HistogramSelector/example/index.js
+++ b/src/InfoViz/Native/HistogramSelector/example/index.js
@@ -55,9 +55,9 @@ provider.assignLegend(['colors', 'shapes']);
 
 // activate scoring gui
 const scores = [
-  { name: 'Yes', color: '#00C900', value: 1 },
-  { name: 'Maybe', color: '#FFFF00', value: 0 },
-  { name: 'No', color: '#C90000', value: -1 },
+  { name: 'No', color: '#FDAE61', value: -1 },
+  { name: 'Maybe', color: '#FFFFBF', value: 0 },
+  { name: 'Yes', color: '#A6D96A', value: 1 },
 ];
 provider.setScores(scores);
 provider.setDefaultScore(1);
@@ -70,10 +70,14 @@ const histogramSelector = HistogramSelector.newInstance({
 });
 // set a target number per row.
 histogramSelector.requestNumBoxesPerRow(4);
-// Or show a single variable as the focus.
-histogramSelector.displaySingleHistogram(provider.getFieldNames()[1]);
+// Or show a single variable as the focus, possibly disabling switching to other vars.
+// histogramSelector.displaySingleHistogram(provider.getFieldNames()[5], true);
 // and maybe set a scoring annotation:
-// histogramSelector.setDefaultScorePartition(provider.getFieldNames()[1]);
+// histogramSelector.setDefaultScorePartition(provider.getFieldNames()[5]);
+// test reset:
+// window.setTimeout(() => {
+//   histogramSelector.requestNumBoxesPerRow(4);
+// }, 5000);
 
 // Create field selector
 const fieldSelector = FieldSelector.newInstance({ provider, container: fieldSelectorContainer });

--- a/src/InfoViz/Native/HistogramSelector/example/index.js
+++ b/src/InfoViz/Native/HistogramSelector/example/index.js
@@ -68,6 +68,8 @@ const histogramSelector = HistogramSelector.newInstance({
   container: histogramSelectorContainer,
   // defaultScore: 1,
 });
+// set a target number per row.
+histogramSelector.requestNumBoxesPerRow(4);
 
 // Create field selector
 const fieldSelector = FieldSelector.newInstance({ provider, container: fieldSelectorContainer });

--- a/src/InfoViz/Native/HistogramSelector/index.js
+++ b/src/InfoViz/Native/HistogramSelector/index.js
@@ -354,7 +354,7 @@ function histogramSelector(publicAPI, model) {
     }
   };
 
-  function toggleSingleModeEvt(d, i) {
+  function toggleSingleModeEvt(d) {
     if (model.singleModeName === null) {
       model.singleModeName = d.name;
     } else {
@@ -363,8 +363,15 @@ function histogramSelector(publicAPI, model) {
     model.scrollToName = d.name;
     publicAPI.render();
 
-    d3.event.stopPropagation();
+    if (d3.event) d3.event.stopPropagation();
   }
+
+  publicAPI.displaySingleHistogram = (fieldName) => {
+    model.singleModeName = null;
+    if (model.fieldData[fieldName]) {
+      toggleSingleModeEvt(model.fieldData[fieldName]);
+    }
+  };
 
   publicAPI.render = (onlyFieldName = null) => {
     if (model.needData) {

--- a/src/InfoViz/Native/HistogramSelector/index.js
+++ b/src/InfoViz/Native/HistogramSelector/index.js
@@ -37,7 +37,7 @@ function histogramSelector(publicAPI, model) {
   // to before fewer histograms are created to fill the container's width
   let minBoxSize = 200;
   // smallest we'll let it go. Limits boxesPerRow in header GUI.
-  const minBoxSizeLimit = 100;
+  const minBoxSizeLimit = 115;
   const legendSize = 15;
   // hard coded because I did not figure out how to
   // properly query this value from our container.
@@ -551,6 +551,7 @@ function histogramSelector(publicAPI, model) {
         iconCell = trow1
           .append('td')
           .classed(style.legendIcons, true);
+        scoreHelper.createScoreIcon(iconCell);
         iconCell
           .append('i')
             .classed(style.expandIcon, true)
@@ -594,12 +595,15 @@ function histogramSelector(publicAPI, model) {
         .classed(dataActive ? style.selectedBox : style.unselectedBox, true);
 
       // Change interaction icons based on state.
+      const numIcons = (model.singleModeSticky ? 0 : 1) + (scoreHelper.enabled() ? 1 : 0);
+      iconCell.style('width', `${numIcons * 19}px`);
+      scoreHelper.updateScoreIcon(iconCell, def);
       iconCell.select(`.${style.jsExpandIcon}`)
         .attr('class', model.singleModeName === null ? style.expandIcon : style.shrinkIcon)
         .style('display', model.singleModeSticky ? 'none' : null);
       // Apply field name
       fieldCell
-        .style('width', `${model.histWidth - (19)}px`)
+        .style('width', `${model.histWidth - (numIcons * 19)}px`)
         .text(def.name);
 
       // adjust some settings based on current size

--- a/src/InfoViz/Native/HistogramSelector/score.js
+++ b/src/InfoViz/Native/HistogramSelector/score.js
@@ -120,6 +120,16 @@ export default function init(inPublicAPI, inModel) {
     }
   }
 
+  publicAPI.setDefaultScorePartition = (fieldName) => {
+    const def = model.fieldData[fieldName];
+    if (def) {
+      def.editScore = true;
+      def.dividers = [createDefaultDivider(0.5 * (def.hobj.min + def.hobj.max), 0)];
+      def.regions = [2, 0];
+      sendScores(def, def.hobj);
+    }
+  };
+
   const scoredHeaderClick = (d) => {
     displayOnlyScored = !displayOnlyScored;
     publicAPI.render();

--- a/style/InfoVizNative/HistogramSelector.mcss
+++ b/style/InfoVizNative/HistogramSelector.mcss
@@ -5,6 +5,7 @@
 .jsDividerPopup,
 .jsDividerUncertaintyInput,
 .jsDividerValueInput,
+.jsExpandIcon,
 .jsFieldName,
 .jsFieldsIcon,
 .jsGHist,
@@ -16,6 +17,7 @@
 .jsHeaderSingleField,
 .jsHistRect,
 .jsLegend,
+.jsLegendIcons,
 .jsLegendRow,
 .jsOverlay,
 .jsScore,
@@ -130,6 +132,18 @@
   padding-right: 10px;
 }
 
+.expandIcon {
+  composes: jsExpandIcon;
+  composes: icon;
+  composes: fa-expand from 'font-awesome/css/font-awesome.css';
+  vertical-align: middle;
+}
+.shrinkIcon {
+  composes: jsExpandIcon;
+  composes: icon;
+  composes: fa-th-large from 'font-awesome/css/font-awesome.css';
+  vertical-align: middle;
+}
 
 
 .histogramSelectorCell {
@@ -153,7 +167,7 @@
 }
 
 .baseFieldName {
-  width: 99%;
+  width: auto;
   white-space: nowrap;
   overflow: hidden;
   text-align: left;
@@ -192,13 +206,23 @@
   opacity: 1;
 }
 
+.legendIcons {
+  composes: jsLegendIcons;
+  width: 19px;
+  visibility: hidden;
+}
+
+
 .baseLegendRow:hover {
   background-color: #ccd;
 }
-.baseLegendRow:hover .baseLegend, .baseLegendRow:hover .baseFieldName {
+.jsLegendRow:hover .baseLegend, .jsLegendRow:hover .baseFieldName, .jsLegendRow:hover .legendIcons {
   border-bottom: 1px solid #000;
 }
 
+.jsLegendRow:hover .jsLegendIcons {
+  visibility: visible;
+}
 .sparkline {
   composes: jsSparkline;
   composes: histogramSelectorCell;
@@ -238,8 +262,11 @@
 .jsBox:hover .baseLegendRow {
   background-color: #ccd;
 }
-.jsBox:hover .baseLegend, .jsBox:hover .baseFieldName {
+.jsBox:hover .baseLegend, .jsBox:hover .baseFieldName, .jsBox:hover .legendIcons {
   border-bottom: 1px solid #000;
+}
+.jsBox:hover .jsLegendIcons {
+  visibility: visible;
 }
 
 .histRect {

--- a/style/InfoVizNative/HistogramSelector.mcss
+++ b/style/InfoVizNative/HistogramSelector.mcss
@@ -5,11 +5,13 @@
 .jsDividerPopup,
 .jsDividerUncertaintyInput,
 .jsDividerValueInput,
+.jsDividerValuePopup,
 .jsExpandIcon,
 .jsFieldName,
 .jsFieldsIcon,
 .jsGHist,
 .jsGRect,
+.jsHeader,
 .jsHeaderBoxes,
 .jsHeaderBoxesNum,
 .jsHeaderLabel,
@@ -46,6 +48,7 @@
 }
 
 .header {
+  composes: jsHeader;
   font-family: "Optima", "Linux Biolinum", "URW Classico", sans;
   font-size: 10pt;
   font-weight: bold;
@@ -351,6 +354,10 @@
 }
 .dividerPopup {
   composes: jsDividerPopup;
+  composes: popup;
+}
+.dividerValuePopup {
+  composes: jsDividerValuePopup;
   composes: popup;
 }
 

--- a/style/InfoVizNative/HistogramSelector.mcss
+++ b/style/InfoVizNative/HistogramSelector.mcss
@@ -26,12 +26,13 @@
 .jsScoreBackground,
 .jsScoreChoice,
 .jsScoreDivLabel,
-.jsScoredIcon,
 .jsScoredHeader,
+.jsScoreIcon,
 .jsScoreLabel,
 .jsScorePopup,
 .jsScoreRect,
 .jsScoreUncertainty,
+.jsShowScoredIcon,
 .jsSparkline,
 .jsTr2 {
 
@@ -87,11 +88,11 @@
   composes: allIcon;
 }
 .onlyScoredIcon {
-  composes: jsScoredIcon;
+  composes: jsShowScoredIcon;
   composes: selectedIcon;
 }
 .allScoredIcon {
-  composes: jsScoredIcon;
+  composes: jsShowScoredIcon;
   composes: allIcon;
 }
 
@@ -135,19 +136,34 @@
   padding-right: 10px;
 }
 
+.legendIcon {
+  vertical-align: middle;
+  padding: 1px 2px;
+}
 .expandIcon {
   composes: jsExpandIcon;
   composes: icon;
   composes: fa-expand from 'font-awesome/css/font-awesome.css';
-  vertical-align: middle;
-}
+  composes: legendIcon;
+  }
 .shrinkIcon {
   composes: jsExpandIcon;
   composes: icon;
   composes: fa-th-large from 'font-awesome/css/font-awesome.css';
-  vertical-align: middle;
+  composes: legendIcon;
 }
-
+.scoreStartIcon {
+  composes: jsScoreIcon;
+  composes: icon;
+  composes: fa-star-o from 'font-awesome/css/font-awesome.css';
+  composes: legendIcon;
+}
+.scoreEndIcon {
+  composes: jsScoreIcon;
+  composes: icon;
+  composes: fa-star from 'font-awesome/css/font-awesome.css';
+  composes: legendIcon;
+}
 
 .histogramSelectorCell {
   padding: 0px;
@@ -211,7 +227,6 @@
 
 .legendIcons {
   composes: jsLegendIcons;
-  width: 19px;
   visibility: hidden;
 }
 


### PR DESCRIPTION
@scottwittenburg 
New public API for setting boxes/row or single histogram mode, and setting a partition annotation useful for thresholding. HS example has the calls, commented out. 

Setting the threshold annotation also puts it in the mode where the annotation is 'locked' so only the partition value can be changed - no changing scores or deleting/adding partitions. 