### PR TITLE
fix(examples) Examples need babel-polyfill for IE 11

### DIFF
--- a/src/InfoViz/Core/LegendProvider/example/index.js
+++ b/src/InfoViz/Core/LegendProvider/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React              from 'react';
 import ReactDOM           from 'react-dom';
 

--- a/src/InfoViz/Native/HistogramSelector/example/index.js
+++ b/src/InfoViz/Native/HistogramSelector/example/index.js
@@ -1,4 +1,5 @@
 import 'normalize.css';
+import 'babel-polyfill';
 
 import sizeHelper   from '../../../../Common/Misc/SizeHelper';
 

--- a/src/InfoViz/Native/MutualInformationDiagram/example/index.js
+++ b/src/InfoViz/Native/MutualInformationDiagram/example/index.js
@@ -1,4 +1,5 @@
 import 'normalize.css';
+import 'babel-polyfill';
 
 import sizeHelper   from '../../../../Common/Misc/SizeHelper';
 

--- a/src/InfoViz/Native/ParallelCoordinates/example/index.js
+++ b/src/InfoViz/Native/ParallelCoordinates/example/index.js
@@ -1,4 +1,5 @@
 import 'normalize.css';
+import 'babel-polyfill';
 
 import sizeHelper   from '../../../../Common/Misc/SizeHelper';
 

--- a/src/React/CollapsibleControls/QueryDataModelControl/example/index.js
+++ b/src/React/CollapsibleControls/QueryDataModelControl/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import jsonData                 from '../../../Widgets/QueryDataModelWidget/example/info.js';
 import QueryDataModel           from '../../../../IO/Core/QueryDataModel';
 import QueryDataModelControl    from '..';

--- a/src/React/Widgets/AnnotationEditorWidget/example/index.js
+++ b/src/React/Widgets/AnnotationEditorWidget/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import AnnotationEditorWidget from '..';
 import React                from 'react';
 import ReactDOM             from 'react-dom';

--- a/src/React/Widgets/ColorMapEditorWidget/example/index.js
+++ b/src/React/Widgets/ColorMapEditorWidget/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ColorMapEditorWidget from '..';
@@ -8,7 +9,7 @@ import presets from './presets.json';
 
 const ColorMapEditorTestWidget = React.createClass({
   displayName: 'ColorMapEditorTestWidget',
-  
+
   getInitialState() {
     return {
       currentPreset: 'Cool to Warm',

--- a/src/React/Widgets/DoubleSliderWidget/example/index.js
+++ b/src/React/Widgets/DoubleSliderWidget/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import DoubleSliderWidget   from '..';
 import React                from 'react';
 import ReactDOM             from 'react-dom';

--- a/src/React/Widgets/GitTreeWidget/example/index.js
+++ b/src/React/Widgets/GitTreeWidget/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React            from 'react';
 import ReactDOM         from 'react-dom';
 import GitTreeWidget    from '..';

--- a/src/React/Widgets/PieceWiseFunctionEditorWidget/example/index.js
+++ b/src/React/Widgets/PieceWiseFunctionEditorWidget/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PieceWiseFunctionEditorWidget from '..';

--- a/src/React/Widgets/ProxyEditorWidget/example/index.js
+++ b/src/React/Widgets/ProxyEditorWidget/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React              from 'react';
 import ReactDOM           from 'react-dom';
 import ProxyEditorWidget  from '..';

--- a/src/React/Widgets/SelectionEditorWidget/example/index.js
+++ b/src/React/Widgets/SelectionEditorWidget/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import SelectionEditorWidget from '..';
 import React                from 'react';
 import ReactDOM             from 'react-dom';

--- a/src/React/Widgets/SvgIconWidget/example/index.js
+++ b/src/React/Widgets/SvgIconWidget/example/index.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import React              from 'react';
 import ReactDOM           from 'react-dom';
 import SvgIconWidget      from '..';


### PR DESCRIPTION
Internet explorer doesn't support Object.assign() -
import babel-polyfill for examples that need it.

@jourdain it works! There are still some other problems on IE11 though.