### PR TITLE
fix(HistogramSelector): Abs uncertainty, scoreHelper refactor

### DIFF
--- a/src/InfoViz/Native/HistogramSelector/index.js
+++ b/src/InfoViz/Native/HistogramSelector/index.js
@@ -505,8 +505,7 @@ function histogramSelector(publicAPI, model) {
         iconCell = trow1
           .append('td')
           .classed(style.legendIcons, true);
-        scoreHelper.createSaveIcon(iconCell);
-        scoreHelper.createScoreIcon(iconCell);
+        scoreHelper.createScoreIcons(iconCell);
         iconCell
           .append('i')
             .classed(style.expandIcon, true)
@@ -550,10 +549,10 @@ function histogramSelector(publicAPI, model) {
         .classed(dataActive ? style.selectedBox : style.unselectedBox, true);
 
       // Change interaction icons based on state.
-      const numIcons = 1 /* save icon */ + (model.singleModeSticky ? 0 : 1) + (scoreHelper.enabled() ? 1 : 0);
-      iconCell.style('width', `${numIcons * 19}px`);
-      scoreHelper.updateScoreIcon(iconCell, def);
-      scoreHelper.updateSaveIcon(iconCell, def);
+      // scoreHelper has save icon and score icon.
+      const numIcons = (model.singleModeSticky ? 0 : 1) + scoreHelper.numScoreIcons();
+      iconCell.style('width', `${(numIcons * 15) + 6}px`);
+      scoreHelper.updateScoreIcons(iconCell, def);
       iconCell.select(`.${style.jsExpandIcon}`)
         .attr('class', model.singleModeName === null ? style.expandIcon : style.shrinkIcon)
         .style('display', model.singleModeSticky ? 'none' : null);

--- a/src/React/Widgets/SelectionEditorWidget/partition/DividerRender.js
+++ b/src/React/Widgets/SelectionEditorWidget/partition/DividerRender.js
@@ -84,8 +84,6 @@ export default function dividerRender(props) {
             onChange={onChange}
             onBlur={onBlur}
           />
-          <div className={style.inequality}>%
-          </div>
         </span>
         ) : null
       }

--- a/style/InfoVizNative/HistogramSelector.mcss
+++ b/style/InfoVizNative/HistogramSelector.mcss
@@ -249,6 +249,9 @@
 .legendIcons {
   composes: jsLegendIcons;
   visibility: hidden;
+  padding-right: 1px;
+  padding-left: 0px;
+  text-align: right;
 }
 
 
@@ -297,6 +300,10 @@
   composes: box;
   composes: hidden;
 }
+.jsBox td, .jsBox tr {
+  padding: 1px;
+}
+
 /* When hovering over the box, set the legendRow's styles */
 .jsBox:hover .baseLegendRow {
   background-color: #ccd;


### PR DESCRIPTION
Change to uncertainty in the same units as the histogram.
Max uncertainty is half the histogram range.

Consolidate scoreHelper icon methods. Remove the save icon
completely if there's no annotation store.
Remove unused hobj argument a few places.