### PR TITLE
fix(HistogramSelector): no white boxes in Chrome

### DIFF
--- a/src/InfoViz/Native/HistogramSelector/index.js
+++ b/src/InfoViz/Native/HistogramSelector/index.js
@@ -520,6 +520,7 @@ function histogramSelector(publicAPI, model) {
       let legendCell = trow1.select(`.${style.jsLegend}`);
       let fieldCell = trow1.select(`.${style.jsFieldName}`);
       let iconCell = trow1.select(`.${style.jsLegendIcons}`);
+      let iconCellViz = iconCell.select(`.${style.jsLegendIconsViz}`);
       let svgGr = tdsl.select('svg').select(`.${style.jsGHist}`);
       // let svgOverlay = svgGr.select(`.${style.jsOverlay}`);
 
@@ -547,8 +548,11 @@ function histogramSelector(publicAPI, model) {
         iconCell = trow1
           .append('td')
           .classed(style.legendIcons, true);
-        scoreHelper.createScoreIcons(iconCell);
-        iconCell
+        iconCellViz = iconCell
+          .append('span')
+          .classed(style.legendIconsViz, true);
+        scoreHelper.createScoreIcons(iconCellViz);
+        iconCellViz
           .append('i')
             .classed(style.expandIcon, true)
             .on('click', toggleSingleModeEvt);
@@ -594,8 +598,8 @@ function histogramSelector(publicAPI, model) {
       // scoreHelper has save icon and score icon.
       const numIcons = (model.singleModeSticky ? 0 : 1) + scoreHelper.numScoreIcons(def);
       iconCell.style('width', `${(numIcons * 15) + 6}px`);
-      scoreHelper.updateScoreIcons(iconCell, def);
-      iconCell.select(`.${style.jsExpandIcon}`)
+      scoreHelper.updateScoreIcons(iconCellViz, def);
+      iconCellViz.select(`.${style.jsExpandIcon}`)
         .attr('class', model.singleModeName === null ? style.expandIcon : style.shrinkIcon)
         .style('display', model.singleModeSticky ? 'none' : null);
       // Apply field name

--- a/style/InfoVizNative/HistogramSelector.mcss
+++ b/style/InfoVizNative/HistogramSelector.mcss
@@ -20,6 +20,7 @@
 .jsHistRect,
 .jsLegend,
 .jsLegendIcons,
+.jsLegendIconsViz,
 .jsLegendRow,
 .jsOverlay,
 .jsScore,
@@ -263,12 +264,16 @@
 
 .legendIcons {
   composes: jsLegendIcons;
-  visibility: hidden;
   padding-right: 1px;
   padding-left: 0px;
   text-align: right;
+  border-bottom: 1px solid #fff;
 }
 
+.legendIconsViz {
+  composes: jsLegendIconsViz;
+  visibility: hidden;
+}
 
 .baseLegendRow:hover {
   background-color: #ccd;
@@ -277,7 +282,7 @@
   border-bottom: 1px solid #000;
 }
 
-.jsLegendRow:hover .jsLegendIcons {
+.jsLegendRow:hover .jsLegendIconsViz {
   visibility: visible;
 }
 .sparkline {
@@ -326,7 +331,7 @@
 .jsBox:hover .baseLegend, .jsBox:hover .baseFieldName, .jsBox:hover .legendIcons {
   border-bottom: 1px solid #000;
 }
-.jsBox:hover .jsLegendIcons {
+.jsBox:hover .jsLegendIconsViz {
   visibility: visible;
 }
 


### PR DESCRIPTION
Hiding the iconCell with a solid background color for the row
causes a white iconCell in Chrome. Hide a nested span instead.

@scottwittenburg 