### PR TITLE
fix(HistogramSelector): Fix region update - no references

### DIFF
--- a/src/InfoViz/Native/HistogramSelector/score.js
+++ b/src/InfoViz/Native/HistogramSelector/score.js
@@ -111,7 +111,7 @@ export default function init(inPublicAPI, inModel) {
 
     // don't replace the default region with an empty region, so UI can display the default region.
     if (regions.length > 0 && !(regions.length === 1 && regions[0] === model.defaultScore)) {
-      def.regions = regions;
+      def.regions = [].concat(regions);
       def.dividers = dividers;
     }
   }


### PR DESCRIPTION
Don't stash a reference to the annotation's scores array -
make a copy instead. Fixes updates from the Annot Editor.

@scottwittenburg 