### PR TITLE
fix(IE 11): internet explorer 11 compatibility

### DIFF
--- a/src/IO/Core/ProcessLauncher/index.js
+++ b/src/IO/Core/ProcessLauncher/index.js
@@ -22,9 +22,10 @@ export default class ProcessLauncher {
 
     xhr.open('POST', url, true);
     xhr.responseType = 'json';
+    const supportsJson = 'response' in xhr && xhr.responseType === 'json';
 
     xhr.onload = (e) => {
-      var response = xhr.response;
+      const response = supportsJson ? xhr.response : JSON.parse(xhr.response);
       if (xhr.status === 200 && !response.error) {
         // Add connection to our global list
         connections.push(response);
@@ -47,10 +48,11 @@ export default class ProcessLauncher {
 
     xhr.open('GET', url, true);
     xhr.responseType = 'json';
+    const supportsJson = 'response' in xhr && xhr.responseType === 'json';
 
     xhr.onload = (e) => {
       if (this.status === 200) {
-        this.emit(CONNECTION_INFO_TOPIC, xhr.response);
+        this.emit(CONNECTION_INFO_TOPIC, supportsJson ? xhr.response : JSON.parse(xhr.response));
         return;
       }
       this.emit(ERROR_TOPIC, xhr.response);
@@ -69,10 +71,11 @@ export default class ProcessLauncher {
 
     xhr.open('DELETE', url, true);
     xhr.responseType = 'json';
+    const supportsJson = 'response' in xhr && xhr.responseType === 'json';
 
     xhr.onload = (e) => {
       if (this.status === 200) {
-        const response = xhr.response;
+        const response = supportsJson ? xhr.response : JSON.parse(xhr.response);
         // Remove connection from the list
         // FIXME / TODO
         this.emit(PROCESS_STOPPED_TOPIC, response);

--- a/src/InfoViz/Native/HistogramSelector/score.js
+++ b/src/InfoViz/Native/HistogramSelector/score.js
@@ -524,7 +524,7 @@ export default function init(inPublicAPI, inModel) {
     const uncertDispScale = 1; // was 100 for uncertainty as a %.
 
     dPopupDiv
-      .style('display', 'initial');
+      .style('display', null);
     positionPopup(dPopupDiv, coord[0] - topMargin - (0.5 * rowHeight),
                   (coord[1] + model.headerSize) - (topMargin + (2 * rowHeight)));
 
@@ -645,7 +645,7 @@ export default function init(inPublicAPI, inModel) {
     const formatter = d3.format('.4g');
 
     dPopupDiv
-      .style('display', 'initial');
+      .style('display', null);
     positionPopup(dPopupDiv, coord[0] - topMargin - (0.5 * rowHeight),
                   (coord[1] + model.headerSize) - (topMargin + (0.5 * rowHeight)));
 
@@ -775,7 +775,7 @@ export default function init(inPublicAPI, inModel) {
     const rowHeight = 26;
 
     sPopupDiv
-      .style('display', 'initial');
+      .style('display', null);
     positionPopup(sPopupDiv, coord[0] - topMargin - (0.6 * rowHeight),
                   (coord[1] + model.headerSize) - (topMargin + ((0.6 + selRow) * rowHeight)));
 

--- a/src/InfoViz/Native/ParallelCoordinates/index.js
+++ b/src/InfoViz/Native/ParallelCoordinates/index.js
@@ -177,25 +177,27 @@ function parallelCoordinate(publicAPI, model) {
 
   function drawAxisControls(controlsDataModel) {
     // Manipulate the control widgets svg DOM
-    const svg = d3
+    const svgGr = d3
       .select(model.container)
       .select('svg')
       .select('g.axis-control-elements');
 
-    const axisControlNodes = svg
-      .selectAll('g.axis-control-elements')
+    const axisControlNodes = svgGr
+      .selectAll('g.axis-control-element')
       .data(controlsDataModel);
 
     axisControlNodes.enter()
       .append('g')
-      .classed('axis-control-elements', true)
+      .classed('axis-control-element', true)
       .classed(style.axisControlElements, true)
+      // TODO Can't use .html on svg without polyfill: https://github.com/d3/d3-3.x-api-reference/blob/master/Selections.md#html
+      // fails in IE11
       .html(axisControlSvg);
 
     axisControlNodes.exit().remove();
 
     const scale = 0.5;
-    svg.selectAll('g.axis-control-elements')
+    axisControlNodes
       .classed(style.upsideDown, (d, i) => !d.orient)
       .classed(style.rightsideUp, (d, i) => d.orient)
       .attr('transform', function inner(d, i) {

--- a/style/ComponentNative/Composite.mcss
+++ b/style/ComponentNative/Composite.mcss
@@ -6,7 +6,7 @@
 }
 
 .viewport {
-  flex: 1;
+  flex: 1 0 auto;
   position: relative;
 }
 

--- a/style/ComponentReact/WorkbenchController.mcss
+++ b/style/ComponentReact/WorkbenchController.mcss
@@ -18,7 +18,7 @@
 }
 
 .stretch {
-  flex: 1;
+  flex: 1 0 auto;
 }
 
 .layout {

--- a/style/ReactWidgets/AnnotationEditorWidget.mcss
+++ b/style/ReactWidgets/AnnotationEditorWidget.mcss
@@ -76,11 +76,11 @@
 
 .nameInput {
   min-width: 10px;
-  flex: 2;
+  flex: 2 0 auto;
 }
 
 .label {
-  flex: 1;
+  flex: 1 0 auto;
   font-weight: bold;
   margin-right: 20px;
 }

--- a/style/ReactWidgets/AnnotationEditorWidget.mcss
+++ b/style/ReactWidgets/AnnotationEditorWidget.mcss
@@ -65,7 +65,7 @@
 }
 
 .flexItem {
-  flex: 1;
+  flex: 1 0 auto;
   min-width: 10px;
   z-index: 1;
 }

--- a/style/ReactWidgets/AnnotationStoreEditorWidget.mcss
+++ b/style/ReactWidgets/AnnotationStoreEditorWidget.mcss
@@ -43,7 +43,7 @@
 }
 
 .editor {
-  flex: 1;
+  flex: 1 0 auto;
   border: 1px solid #aaa;
   overflow-y: auto;
   margin: 10px;

--- a/style/ReactWidgets/TextInputWidget.mcss
+++ b/style/ReactWidgets/TextInputWidget.mcss
@@ -5,7 +5,7 @@
 }
 
 .entry {
-    flex: 1;
+    flex: 1 0 auto;
 }
 
 .button {


### PR DESCRIPTION
IE 11 changes:

xhr.requestType = 'json' not supported, detect and parse text.

style display = initial not supported, clear display style instead.

style: flex: 1 on IE 11 defaults to flex: 1 1 auto.
Everyone else uses flex: 1 0 auto. Specify explicitly
so IE 11 will match.

@jourdain I did a search and replace, and mostly verified that things work better on IE 11. Is this enough testing for you?