### PR TITLE
fix(SelectionEditorWidget): clamp uncertainties to prevent overlap

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     // Not for us ;-)
     'jsx-a11y/label-has-for': 0,
     'no-console': 0,
+    'import/no-named-as-default-member': 0,
   },
   'settings': {
     'import/resolver': 'webpack'

--- a/src/React/Widgets/AnnotationEditorWidget/example/index.js
+++ b/src/React/Widgets/AnnotationEditorWidget/example/index.js
@@ -1,7 +1,8 @@
+/* global document */
 import 'babel-polyfill';
-import AnnotationEditorWidget from '..';
 import React                from 'react';
 import ReactDOM             from 'react-dom';
+import AnnotationEditorWidget from '..';
 import SelectionBuilder from '../../../../Common/Misc/SelectionBuilder';
 import AnnotationBuilder from '../../../../Common/Misc/AnnotationBuilder';
 
@@ -28,9 +29,13 @@ const rangeSelection = SelectionBuilder.range({
 
 const partitionSelection = SelectionBuilder.partition('pressure', [
   { value: 90, uncertainty: 0 },
-  { value: 101.3, uncertainty: 20 },
+  { value: 101.3, uncertainty: 10 },
   { value: 200, uncertainty: 40, closeToLeft: true },
 ]);
+const ranges = {
+  pressure: [0, 600],
+  temperature: [-270, 1000],
+};
 
 const annotations = [
   AnnotationBuilder.annotation(rangeSelection, [0]),
@@ -49,6 +54,7 @@ function render() {
         <div key={idx}>
           <AnnotationEditorWidget
             scores={scores}
+            ranges={ranges}
             annotation={annotation}
             getLegend={legendService.getLegend}
             // rationaleOpen={true}

--- a/src/React/Widgets/SelectionEditorWidget/example/index.js
+++ b/src/React/Widgets/SelectionEditorWidget/example/index.js
@@ -1,7 +1,8 @@
+/* global document */
 import 'babel-polyfill';
-import SelectionEditorWidget from '..';
 import React                from 'react';
 import ReactDOM             from 'react-dom';
+import SelectionEditorWidget from '..';
 import SelectionBuilder from '../../../../Common/Misc/SelectionBuilder';
 
 import LegendProvider from '../../../../InfoViz/Core/LegendProvider';
@@ -21,9 +22,14 @@ const rangeSelection = SelectionBuilder.range({
 
 const partitionSelection = SelectionBuilder.partition('pressure', [
   { value: 90, uncertainty: 0 },
-  { value: 101.3, uncertainty: 20 },
+  { value: 101.3, uncertainty: 10 },
   { value: 200, uncertainty: 40, closeToLeft: true },
 ]);
+const ranges = {
+  pressure: [0, 600],
+  temperature: [-270, 1000],
+};
+
 
 const selectionTypes = [rangeSelection, partitionSelection, SelectionBuilder.convertToRuleSelection(rangeSelection)];
 const legendService = LegendProvider.newInstance({ legendEntries: ['pressure', 'temperature'] });
@@ -38,6 +44,7 @@ function render() {
         <SelectionEditorWidget
           key={idx}
           selection={selection}
+          ranges={ranges}
           getLegend={legendService.getLegend}
           onChange={(newSelection, save) => {
             selectionTypes[idx] = newSelection;

--- a/src/React/Widgets/SelectionEditorWidget/partition/index.js
+++ b/src/React/Widgets/SelectionEditorWidget/partition/index.js
@@ -4,20 +4,59 @@ import FieldRender      from './FieldRender';
 import DividerRender    from './DividerRender';
 import SelectionBuilder from '../../../../Common/Misc/SelectionBuilder';
 
-export default function partitionSelection(props) {
-  const dividers = props.selection.partition.dividers;
-  const fieldName = props.selection.partition.variable;
+function clampDividerUncertainty(dividers, index, inMaxUncertainty) {
+  const divider = dividers[index];
+  const val = divider.value;
+  const uncertScale = 1.0;
+  let maxUncertainty = inMaxUncertainty;
+  // Note comparison with low/high divider is signed. If val indicates divider has been
+  // moved _past_ the neighboring divider, low/high will be negative.
+  if (index > 0) {
+    const low = dividers[index - 1].value + (dividers[index - 1].uncertainty * uncertScale);
+    maxUncertainty = Math.min(maxUncertainty, (val - low) / uncertScale);
+  }
+  if (index < dividers.length - 1) {
+    const high = dividers[index + 1].value - (dividers[index + 1].uncertainty * uncertScale);
+    maxUncertainty = Math.min((high - val) / uncertScale, maxUncertainty);
+  }
+  // make sure uncertainty is zero when val has passed a neighbor.
+  maxUncertainty = Math.max(maxUncertainty, 0);
+  divider.uncertainty = Math.min(maxUncertainty, divider.uncertainty);
+}
 
+function clampDivider(selection, index, ranges) {
+  // make sure uncertainties don't overlap.
+  const divider = selection.partition.dividers[index];
+
+  let maxUncertainty = Number.MAX_VALUE;
+  const minMax = ranges ? ranges[selection.partition.variable] : undefined;
+  if (minMax) {
+    maxUncertainty = 0.5 * (minMax[1] - minMax[0]);
+    // if available, clamp divider value to min/max of its range.
+    divider.value = Math.min(minMax[1], Math.max(minMax[0], divider.value));
+  }
+  clampDividerUncertainty(selection.partition.dividers, index, maxUncertainty);
+  // Re-sort dividers so uncertainty clamping works next time.
+  selection.partition.dividers.sort((a, b) => (a.value - b.value));
+  // make sure uncertainties don't overlap.
+  selection.partition.dividers.forEach((divdr, i) => {
+    clampDividerUncertainty(selection.partition.dividers, i, maxUncertainty);
+  });
+}
+
+export default function partitionSelection(props) {
   const onChange = (changedPath, editing = false) => {
     // clone, so we don't step on whatever is current.
     const selection = JSON.parse(JSON.stringify(props.selection));
     if (changedPath[0] === 'dividers') {
-      const divider = selection.partition.dividers[changedPath[1]];
+      const index = changedPath[1];
+      const divider = selection.partition.dividers[index];
       const changeItemKey = changedPath[2];
       const newValue = changedPath[3];
 
       // console.log('change', divider, changeItemKey, newValue);
       divider[changeItemKey] = newValue;
+      if (!editing) clampDivider(selection, index, props.ranges);
     }
 
     // Notify happens in parent
@@ -35,6 +74,9 @@ export default function partitionSelection(props) {
 
     props.onChange(SelectionBuilder.markModified(selection), true);
   };
+
+  const dividers = props.selection.partition.dividers;
+  const fieldName = props.selection.partition.variable;
 
   return (
     <div style={{ position: 'relative' }}>


### PR DESCRIPTION
Following a similar method to the HistogramSelector, clamp
values when a range is provided, and clamp uncertainties
so they don't overlap other dividers. Re-sort dividers
when values change order.

Fix example data so uncertainty doesn't overlap.

Fix some linting warnings.