### PR TITLE
fix(HistogramSelector): Size legend consistently

### DIFF
--- a/style/InfoVizNative/HistogramSelector.mcss
+++ b/style/InfoVizNative/HistogramSelector.mcss
@@ -48,6 +48,7 @@
   bottom: 0px;
   left: 0px;
   right: 0px;
+  box-sizing: border-box;
 }
 
 .header {
@@ -217,7 +218,7 @@
   composes: baseLegend;
 }
 .legendSvg {
-  padding: 3px 3px 2px 3px;
+  margin: 3px 3px 2px 3px;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
Legend icon was shrinking in external container. Switch from
'padding' to 'margin' to ensure legend SVG has consistent size.