### PR TITLE
fix(ParallelCoordinates): Add selection resize, single delete

### DIFF
--- a/src/InfoViz/Native/ParallelCoordinates/Axis.js
+++ b/src/InfoViz/Native/ParallelCoordinates/Axis.js
@@ -30,6 +30,12 @@ export default class Axis {
 
   updateSelection(selectionIndex, start, end) {
     const entry = this.selections[selectionIndex].interval = [start, end];
+    // if entire selection is outside range, delete it.
+    if ((start < this.range[0] && end < this.range[0]) ||
+        (end > this.range[1] && start > this.range[1])) {
+      this.selections.splice(selectionIndex, 1);
+      return;
+    }
 
     // Clamp to axis range
     if (start < this.range[0]) {
@@ -40,7 +46,7 @@ export default class Axis {
       entry[1] = this.range[1];
     }
 
-    // FIXME trigger notification
+    // notification handled by AxesManager
   }
 
   addSelection(start, end, endpoints = '**', uncertainty) {


### PR DESCRIPTION
You can resize a selection bar if you drag within 6 pixels of the
ends, or 1/3 of the bar height, if it's too small. This simple
resize works pretty well, but we may want to allow resize when
starting just outside the bar boundaries, in the future.

If you drag a bar totally off the end of the axis, it is deleted.

@scottwittenburg @jourdain I think this is useful, and we can refine it later, if needed. What do you think?