### PR TITLE
Plotly chart expansion

### DIFF
--- a/src/React/Renderers/PlotlyRenderer/index.js
+++ b/src/React/Renderers/PlotlyRenderer/index.js
@@ -50,7 +50,7 @@ export default React.createClass({
           displayModeBar: false,
         };
 
-        Plotly.newPlot(container, data.traces, data.layout || layout, config);
+        Plotly.newPlot(container, data.traces, data.layout || layout, data.config || config);
       }
 
       if (data.hover && data.hover.enable === true) {

--- a/src/Rendering/Chart/Histogram2DPlotlyChartBuilder/HistXYZ.js
+++ b/src/Rendering/Chart/Histogram2DPlotlyChartBuilder/HistXYZ.js
@@ -2,7 +2,7 @@ function affine(inMin, val, inMax, outMin, outMax) {
   return (((val - inMin) / (inMax - inMin)) * (outMax - outMin)) + outMin;
 }
 
-export default function Surface3D(chartState, histogram) {
+export default function HistXYZ(chartState, histogram, chartType) {
   if (!histogram) return null;
 
   const nBins = histogram.numberOfBins;
@@ -28,16 +28,29 @@ export default function Surface3D(chartState, histogram) {
   });
 
   return {
+    nonsense: 'unknown value',
     forceNewPlot: chartState.forceNewPlot,
     traces: [
       {
         x,
         y,
         z,
-        type: 'surface',
+        type: chartType,
+        colorscale: chartState.colormap,
+        reversescale: chartState.reversescale,
       },
     ],
+    // redundant axis titles for 2D and 3D plots.
     layout: {
+      margin: {
+        t: 40,
+      },
+      xaxis: {
+        title: histogram.x.name,
+      },
+      yaxis: {
+        title: histogram.y.name,
+      },
       scene: {
         xaxis: {
           title: histogram.x.name,
@@ -49,6 +62,13 @@ export default function Surface3D(chartState, histogram) {
           title: 'Count',
         },
       },
+    },
+    config: {
+      scrollZoom: true,
+      displayModeBar: true,
+      displaylogo: false,
+      showLink: false,
+      modeBarButtonsToRemove: ['sendDataToCloud'],
     },
   };
 }

--- a/src/Rendering/Chart/Histogram2DPlotlyChartBuilder/Scatter.js
+++ b/src/Rendering/Chart/Histogram2DPlotlyChartBuilder/Scatter.js
@@ -1,4 +1,4 @@
-export default function Scatter(chartState, histogram) {
+export default function Scatter(chartState, histogram, chartType) {
   if (!histogram) return null;
 
   const x = [];
@@ -19,21 +19,36 @@ export default function Scatter(chartState, histogram) {
         x,
         y,
         text: color.map(count => (`Count: ${count}`)),
+        type: chartType,
         mode: 'markers',
         marker: {
-          size: 10,
+          size: 12,
+          // size: color,
           color,
+          colorscale: chartState.colormap, // Viridis
+          showscale: true,
+          reversescale: chartState.reversescale,
         },
       },
     ],
     layout: {
       hovermode: 'closest',
+      margin: {
+        t: 40,
+      },
       xaxis: {
         title: histogram.x.name,
       },
       yaxis: {
         title: histogram.y.name,
       },
+    },
+    config: {
+      scrollZoom: true,
+      displayModeBar: true,
+      displaylogo: false,
+      showLink: false,
+      modeBarButtonsToRemove: ['sendDataToCloud'],
     },
   };
 }

--- a/src/Rendering/Chart/Histogram2DPlotlyChartBuilder/ScatterXY.js
+++ b/src/Rendering/Chart/Histogram2DPlotlyChartBuilder/ScatterXY.js
@@ -1,0 +1,53 @@
+export default function ScatterXY(chartState, scatter, chartType) {
+  if (!scatter) return null;
+
+  const x = scatter[0].data;
+  const y = scatter[1].data;
+  const trace2 = {
+    x,
+    y,
+    type: chartType,
+    colorscale: chartState.colormap,
+    reversescale: chartState.reversescale,
+  };
+
+  return {
+    forceNewPlot: chartState.forceNewPlot,
+    traces: [
+      {
+        x,
+        y,
+        type: 'scatter',
+        mode: 'markers',
+        marker: {
+          color: 'rgba(156, 165, 196, 0.65)',
+          line: {
+            color: 'rgba(106, 115, 146, 1.0)',
+            width: 1,
+          },
+          symbol: 'circle',
+          size: 8,
+        },
+      },
+    ].concat(chartType !== 'scatter' ? trace2 : []),
+    layout: {
+      hovermode: 'closest',
+      margin: {
+        t: 40,
+      },
+      xaxis: {
+        title: scatter[0].name,
+      },
+      yaxis: {
+        title: scatter[1].name,
+      },
+    },
+    config: {
+      scrollZoom: true,
+      displayModeBar: true,
+      displaylogo: false,
+      showLink: false,
+      modeBarButtonsToRemove: ['sendDataToCloud'],
+    },
+  };
+}

--- a/src/Rendering/Chart/Histogram2DPlotlyChartBuilder/index.js
+++ b/src/Rendering/Chart/Histogram2DPlotlyChartBuilder/index.js
@@ -1,9 +1,15 @@
 import Monologue   from  'monologue.js';
 import HistXYZ     from './HistXYZ';
-// import Surface3D   from './Surface3D';
 import Scatter     from './Scatter';
 import ScatterXY     from './ScatterXY';
 
+const defaultConfig = {
+  scrollZoom: true,
+  displayModeBar: true,
+  displaylogo: false,
+  showLink: false,
+  modeBarButtonsToRemove: ['sendDataToCloud'],
+};
 const chartFactory = {
   Contour: { builder: HistXYZ, type: 'contour', data: 'histogram' },
   Heatmap: { builder: HistXYZ, type: 'heatmap', data: 'histogram' },
@@ -11,6 +17,14 @@ const chartFactory = {
   ScatterXY: { builder: ScatterXY, type: 'scatter', data: 'scatter' },
   ScatterXYContour: { builder: ScatterXY, type: 'histogram2dcontour', data: 'scatter' },
   Surface3D: { builder: HistXYZ, type: 'surface', data: 'histogram' },
+  Trend: {
+    builder: (chartState, data) => {
+      if (data) data.config = data.config || defaultConfig;
+      return data;
+    },
+    type: 'custom',
+    data: 'plot',
+  },
 };
 
 const DATA_READY_TOPIC = 'data-ready';
@@ -113,6 +127,11 @@ export default class Histogram2DPlotlyChartBuilder {
     this.scatter = scatter;
     this.buildChart();
   }
+  setPlot(plot) {
+    this.chartState.forceNewPlot = true;
+    this.plot = plot;
+    this.buildChart();
+  }
 
   // ------------------------------------------------------------------------
 
@@ -147,6 +166,9 @@ export default class Histogram2DPlotlyChartBuilder {
 
   getChartType() {
     return this.chartState.chartType;
+  }
+  getDataType() {
+    return chartFactory[this.chartState.chartType].data;
   }
 }
 


### PR DESCRIPTION
fix(Histogram2DPlotlyChartBuilder): new types, new data type, workbench integration

Add graph types, and allow plotting of x-y scatter data as well.
Allow setting of colormaps. Remove field selector if embedded in workbench.
Add support for chart generated by the server - pass-through builder.