### PR TITLE
fix(AnnotationEditorWidget): convert 'weight' to number

### DIFF
--- a/src/React/Widgets/AnnotationEditorWidget/index.js
+++ b/src/React/Widgets/AnnotationEditorWidget/index.js
@@ -47,7 +47,7 @@ export default function annotationEditorWidget(props) {
   };
 
   const onAnnotationChange = (event) => {
-    const value = event.target.value;
+    const value = (event.target.type === 'number') ? +event.target.value : event.target.value;
     const name = event.target.name;
     const type = event.type;
 


### PR DESCRIPTION
Make sure the 'weight' parameter is coverted to a number,
by checking for input type==='number'.

@vibraphone 