### PR TITLE
fix(TextInputWidget): add props for editing and esc handling

### DIFF
--- a/src/React/Widgets/TextInputWidget/index.js
+++ b/src/React/Widgets/TextInputWidget/index.js
@@ -13,6 +13,8 @@ export default React.createClass({
     value: React.PropTypes.string,
     maxWidth: React.PropTypes.string,
     icon: React.PropTypes.string,
+    editing: React.PropTypes.bool,
+    escEndsEdit: React.PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -20,12 +22,14 @@ export default React.createClass({
       value: '',
       className: '',
       icon: `${style.checkIcon}`,
+      editing: false,
+      escEndsEdit: false,
     };
   },
 
   getInitialState() {
     return {
-      editing: false,
+      editing: this.props.editing,
       valueRep: this.props.value,
     };
   },
@@ -53,6 +57,10 @@ export default React.createClass({
       this.textInput.blur();
     } else if (e.key === 'Escape') {
       this.setState({ valueRep: this.props.value });
+      if (this.props.escEndsEdit) {
+        // needs to happen at next idle so it happens after setState.
+        setImmediate(() => this.textInput.blur());
+      }
     }
   },
 


### PR DESCRIPTION
New props allow externally setting the 'editing' state of the
widget, and emitting a change event when pressing 'esc'