### PR TITLE
fix(MutualInformationDiagram): Keep chords on resize, reuse groups on render

### DIFF
--- a/src/InfoViz/Native/MutualInformationDiagram/example/index.js
+++ b/src/InfoViz/Native/MutualInformationDiagram/example/index.js
@@ -27,7 +27,7 @@ bodyElt.appendChild(container);
 
 const fieldSelectorContainer = document.createElement('div');
 fieldSelectorContainer.style.position = 'relative';
-fieldSelectorContainer.style.width = '40%';
+fieldSelectorContainer.style.width = '30%';
 fieldSelectorContainer.style.height = '250px';
 fieldSelectorContainer.style.float = 'left';
 bodyElt.appendChild(fieldSelectorContainer);


### PR DESCRIPTION
Track the chord display mode between renders so the current display
is maintained during a resize. Reset when fields are added or removed.

Use the field name as a key for the group, so d3 knows to re-use the
group instead of filling enter() and exit() selections every time
render is called.

Example display tweak (Chrome, windows)