### PR TITLE
fix(HistogramSelector): threshold annot shouldn't be saved

### DIFF
--- a/src/InfoViz/Native/HistogramSelector/index.js
+++ b/src/InfoViz/Native/HistogramSelector/index.js
@@ -335,11 +335,8 @@ function histogramSelector(publicAPI, model) {
   // other histograms in the fields list is disabled.
   // Calling requestNumBoxesPerRow() re-enables switching.
   publicAPI.displaySingleHistogram = (fieldName, disableSwitch) => {
-    model.singleModeName = null;
-    model.singleModeSticky = false;
-    if (model.fieldData[fieldName]) {
-      toggleSingleModeEvt(model.fieldData[fieldName]);
-    }
+    model.singleModeName = fieldName;
+    model.scrollToName = fieldName;
     if (model.singleModeName && disableSwitch) {
       model.singleModeSticky = true;
     } else {

--- a/src/InfoViz/Native/HistogramSelector/score.js
+++ b/src/InfoViz/Native/HistogramSelector/score.js
@@ -117,6 +117,8 @@ export default function init(inPublicAPI, inModel) {
 
   // communicate with the server which regions/dividers have changed.
   function sendScores(def, passive = false) {
+    // when showing a threshold, don't communicate with provider.
+    if (def.lockAnnot) return;
     const scoreData = dividersToPartition(def, model.scores);
     if (scoreData === null) {
       console.error('Cannot translate scores to send to provider');
@@ -175,13 +177,19 @@ export default function init(inPublicAPI, inModel) {
       def.dividers = [createDefaultDivider(0.5 * (minRange + maxRange), 0)];
       // set regions to 'no' | 'yes'
       def.regions = [0, 2];
-      sendScores(def);
-      // set mode that prevents editing the annotation, except for the single divider.
+      // set mode that prevents sending or editing the annotation, except for the single divider.
       def.lockAnnot = true;
+      // sendScores(def);
       setEditScore(def, true);
     } else {
       def.lockAnnot = false;
     }
+  };
+
+  publicAPI.getScoreThreshold = (fieldName) => {
+    const def = model.fieldData[fieldName];
+    if (!def.lockAnnot) console.log('Wrong mode for score threshold, arbitrary results.');
+    return def.dividers[0].value;
   };
 
   const scoredHeaderClick = (d) => {


### PR DESCRIPTION
Don't communicate a threshold annotation with the provider,
and allow a single-sticky name that doesn't exist yet, because
it will soon.