### PR TITLE
fix(HistogramSelector): fix communication of threshold partitions

### DIFF
--- a/src/InfoViz/Native/HistogramSelector/score.js
+++ b/src/InfoViz/Native/HistogramSelector/score.js
@@ -117,8 +117,6 @@ export default function init(inPublicAPI, inModel) {
 
   // communicate with the server which regions/dividers have changed.
   function sendScores(def, passive = false) {
-    // when showing a threshold, don't communicate with provider.
-    if (def.lockAnnot) return;
     const scoreData = dividersToPartition(def, model.scores);
     if (scoreData === null) {
       console.error('Cannot translate scores to send to provider');
@@ -127,6 +125,9 @@ export default function init(inPublicAPI, inModel) {
     if (model.provider.isA('SelectionProvider')) {
       if (!scoreData.name) {
         scoreData.name = `${scoreData.selection.partition.variable} (partition)`;
+        if (model.provider.isA('AnnotationStoreProvider')) {
+          scoreData.name = model.provider.getNextStoredAnnotationName(scoreData.name);
+        }
       }
       if (!passive) {
         model.provider.setAnnotation(scoreData);
@@ -171,19 +172,23 @@ export default function init(inPublicAPI, inModel) {
 
   publicAPI.setDefaultScorePartition = (fieldName) => {
     const def = model.fieldData[fieldName];
-    if (def) {
+    if (!def) return;
+    // possibly the best we can do - check for a threshold-like annotation
+    if (!def.lockAnnot ||
+        !(def.regions && def.regions.length === 2 && def.regions[0] === 0 && def.regions[1] === 2)) {
       // create a divider halfway through.
       const [minRange, maxRange] = getHistRange(def);
       def.dividers = [createDefaultDivider(0.5 * (minRange + maxRange), 0)];
       // set regions to 'no' | 'yes'
       def.regions = [0, 2];
-      // set mode that prevents sending or editing the annotation, except for the single divider.
+      // clear any existing (local) annotation
+      def.annotation = null;
+      // set mode that prevents editing the annotation, except for the single divider.
       def.lockAnnot = true;
-      // sendScores(def);
-      setEditScore(def, true);
-    } else {
-      def.lockAnnot = false;
+      sendScores(def);
     }
+    // we might already have threshold annot, but need to score it.
+    setEditScore(def, true);
   };
 
   publicAPI.getScoreThreshold = (fieldName) => {
@@ -1128,6 +1133,11 @@ export default function init(inPublicAPI, inModel) {
       model.subscriptions.push(model.provider.onAnnotationChange((annotation) => {
         if (annotation.selection.type === 'partition') {
           const field = annotation.selection.partition.variable;
+          // ignore annotation if it's read-only and we aren't
+          if (annotation.readOnly && model.readOnlyFields.indexOf(field) === -1) return;
+          // Vice-versa: single mode, displaying read-only, ignore external annots.
+          if (!annotation.readOnly && model.fieldData[field].lockAnnot) return;
+
           // respond to annotation.
           model.fieldData[field].annotation = annotation;
           partitionToDividers(annotation, model.fieldData[field], model.scores);


### PR DESCRIPTION
A threshold partition needs to be sent to the provider, but only
the source histogram selector should pay attention to it. The annot
editor can still display it read-only, as can ParallelCoords.

In setDefaultScorePartition(), reset the annotation whenever it
doesn't match a single-divider no-yes pattern.