### PR TITLE
Fix(AnnotationBuilder): Supply a default name for range annotations

### DIFF
--- a/src/Common/Misc/AnnotationBuilder/index.js
+++ b/src/Common/Misc/AnnotationBuilder/index.js
@@ -67,6 +67,28 @@ function fork(annotationObj) {
   return Object.assign({}, annotationObj, { generation, id });
 }
 
+function setDefaultName(annotationObject) {
+  if (annotationObject.selection.type === 'range') {
+    const rangeNames = Object.keys(annotationObject.selection.range.variables);
+    if (rangeNames.length > 0) {
+      annotationObject.name = rangeNames[0];
+      if (rangeNames.length > 1) {
+        annotationObject.name += ` & ${rangeNames[1]}`;
+      }
+      if (rangeNames.length > 2) {
+        annotationObject.name += ' &...';
+      }
+    } else {
+      annotationObject.name = 'empty';
+    }
+    annotationObject.name += ' (range)';
+  } else if (annotationObject.selection.type === 'partition') {
+    annotationObject.name = `${annotationObject.selection.partition.variable} (partition)`;
+  } else {
+    annotationObject.name = 'unknown';
+  }
+}
+
 // ----------------------------------------------------------------------------
 
 function markModified(annotationObject) {
@@ -86,6 +108,7 @@ export default {
   EMPTY_ANNOTATION,
   fork,
   markModified,
+  setDefaultName,
   setInitialGenerationNumber,
   update,
   updateReadOnlyFlag,

--- a/src/InfoViz/Native/HistogramSelector/score.js
+++ b/src/InfoViz/Native/HistogramSelector/score.js
@@ -124,7 +124,7 @@ export default function init(inPublicAPI, inModel) {
     }
     if (model.provider.isA('SelectionProvider')) {
       if (!scoreData.name) {
-        scoreData.name = `${scoreData.selection.partition.variable} (partition)`;
+        AnnotationBuilder.setDefaultName(scoreData);
         if (model.provider.isA('AnnotationStoreProvider')) {
           scoreData.name = model.provider.getNextStoredAnnotationName(scoreData.name);
         }

--- a/src/InfoViz/Native/MutualInformationDiagram/index.js
+++ b/src/InfoViz/Native/MutualInformationDiagram/index.js
@@ -329,6 +329,13 @@ function informationDiagram(publicAPI, model) {
           lastAnnotationPushed = model.provider.getAnnotation();
           if (!lastAnnotationPushed || model.provider.shouldCreateNewAnnotation() || lastAnnotationPushed.selection.type !== 'range') {
             lastAnnotationPushed = AnnotationBuilder.annotation(selection, [model.defaultScore], model.defaultWeight);
+            if (lastAnnotationPushed.name === '') {
+              // set default range annotation name
+              AnnotationBuilder.setDefaultName(lastAnnotationPushed);
+              if (model.provider.isA('AnnotationStoreProvider')) {
+                lastAnnotationPushed.name = model.provider.getNextStoredAnnotationName(lastAnnotationPushed.name);
+              }
+            }
           } else {
             lastAnnotationPushed = AnnotationBuilder.update(lastAnnotationPushed, {
               selection,

--- a/src/InfoViz/Native/ParallelCoordinates/index.js
+++ b/src/InfoViz/Native/ParallelCoordinates/index.js
@@ -981,6 +981,13 @@ function parallelCoordinate(publicAPI, model) {
           lastAnnotationPushed = AnnotationBuilder.EMPTY_ANNOTATION;
         } else if (!lastAnnotationPushed || model.provider.shouldCreateNewAnnotation() || lastAnnotationPushed.selection.type !== 'range') {
           lastAnnotationPushed = AnnotationBuilder.annotation(selection, [model.defaultScore], model.defaultWeight);
+          if (lastAnnotationPushed.name === '') {
+            // set default range annotation name
+            AnnotationBuilder.setDefaultName(lastAnnotationPushed);
+            if (model.provider.isA('AnnotationStoreProvider')) {
+              lastAnnotationPushed.name = model.provider.getNextStoredAnnotationName(lastAnnotationPushed.name);
+            }
+          }
         } else {
           lastAnnotationPushed = AnnotationBuilder.update(lastAnnotationPushed, {
             selection,


### PR DESCRIPTION
Derive from the fields that are in the range annotation when
it is created - it doesn't update as fields are added/removed
from the range annotation. Update might be desirable in the
future.