### PR TITLE
fix(HistogramSelector): Scrolling fix for Chrome

### DIFF
--- a/src/InfoViz/Native/HistogramSelector/index.js
+++ b/src/InfoViz/Native/HistogramSelector/index.js
@@ -764,6 +764,7 @@ function histogramSelector(publicAPI, model) {
         .append('div')
         .classed(style.histogramSelector, true);
 
+      model.parameterList.append('span').classed(style.parameterScrollFix, true);
       publicAPI.resize();
 
       setImmediate(scoreHelper.updateFieldAnnotations);

--- a/style/InfoVizNative/HistogramSelector.mcss
+++ b/style/InfoVizNative/HistogramSelector.mcss
@@ -51,6 +51,14 @@
   box-sizing: border-box;
 }
 
+/* fix a chrome bug with scrolling - must be rendered, full-height */
+.parameterScrollFix {
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  width: 1px;
+}
+
 .header {
   composes: jsHeader;
   font-family: "Optima", "Linux Biolinum", "URW Classico", sans;


### PR DESCRIPTION
On current Chrome, windows and mac, scrolling in the histogram
selector jumps backwards as we try to re-arrange divs with
transforms. Add an empty span, with full height of the scrolling
container, to force Chrome to correctly calculate the height of
the scrolled div.

@scottwittenburg lovely, eh?