### PR TITLE
fix(AnnotationStoreEditorWidget): Show edited options when annot cont…

### DIFF
--- a/src/React/Widgets/AnnotationStoreEditorWidget/index.js
+++ b/src/React/Widgets/AnnotationStoreEditorWidget/index.js
@@ -42,8 +42,9 @@ export default function annotationStoreEditorWidget(props) {
 
   if (props.annotation && props.annotations[props.annotation.id]) {
     const storedSelectedAnnotation = props.annotations[props.annotation.id];
-    if (storedSelectedAnnotation.generation === props.annotation.generation ||
-        deepEquals(Object.assign({}, storedSelectedAnnotation, { generation: props.annotation.generation }), props.annotation)) {
+    if ((storedSelectedAnnotation.generation === props.annotation.generation) ||
+        (props.ignoreGeneration &&
+         deepEquals(Object.assign({}, storedSelectedAnnotation, { generation: props.annotation.generation }), props.annotation))) {
       buttons.push(button('Delete', storeAction('delete'), style.deleteIcon));
     } else {
       buttons.push(button('Save as new', storeAction('new'), style.saveAsNewIcon));
@@ -90,6 +91,7 @@ annotationStoreEditorWidget.propTypes = {
   ranges: React.PropTypes.object,
   getLegend: React.PropTypes.func,
   rationaleOpen: React.PropTypes.bool,
+  ignoreGeneration: React.PropTypes.bool,
 
   onAnnotationChange: React.PropTypes.func,
   onChange: React.PropTypes.func,
@@ -99,4 +101,5 @@ annotationStoreEditorWidget.defaultProps = {
   onAnnotationChange(annotation, isEditing) {},
   onChange(action, id, annotation) {},
   rationaleOpen: false,
+  ignoreGeneration: false,
 };

--- a/src/React/Widgets/AnnotationStoreEditorWidget/index.js
+++ b/src/React/Widgets/AnnotationStoreEditorWidget/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import style from 'PVWStyle/ReactWidgets/AnnotationStoreEditorWidget.mcss';
+import deepEquals from 'mout/src/lang/deepEquals';
 
 import ActionListWidget from '../ActionListWidget';
 import AnnotationEditorWidget from '../AnnotationEditorWidget';
@@ -41,7 +42,8 @@ export default function annotationStoreEditorWidget(props) {
 
   if (props.annotation && props.annotations[props.annotation.id]) {
     const storedSelectedAnnotation = props.annotations[props.annotation.id];
-    if (storedSelectedAnnotation.generation === props.annotation.generation) {
+    if (storedSelectedAnnotation.generation === props.annotation.generation ||
+        deepEquals(Object.assign({}, storedSelectedAnnotation, { generation: props.annotation.generation }), props.annotation)) {
       buttons.push(button('Delete', storeAction('delete'), style.deleteIcon));
     } else {
       buttons.push(button('Save as new', storeAction('new'), style.saveAsNewIcon));


### PR DESCRIPTION
…ents change

Use mout deepEquals to check annotation contents before displaying
the options to save an annot. Helps when only the generation is
updated.

@scottwittenburg think this is an OK approach?