### PR TITLE
fix(InlineSvgIconWidget): Provide inline svg icon widget

### DIFF
--- a/config/webpack.loaders.js
+++ b/config/webpack.loaders.js
@@ -29,6 +29,9 @@ module.exports = [
     test: /\.html$/,
     loader: 'html-loader',
   }, {
+    test: /\.isvg$/,
+    loader: 'html-loader?attrs=false',
+  }, {
     test: /\.js$/,
     include: /node_modules(\/|\\)paraviewweb(\/|\\)/,
     loader: 'babel?presets[]=es2015,presets[]=react',

--- a/src/React/Widgets/InlineSvgIconWidget/index.js
+++ b/src/React/Widgets/InlineSvgIconWidget/index.js
@@ -1,0 +1,51 @@
+import React       from 'react';
+
+// Note the default icon uses the viewBox attribute to create a coordinate system,
+// but does not specify height or width attributes on the svg element itself.  This
+// allows us to size the icon with the height/width props provided to this component.
+// Additionally, not providing any attributes controlling final appearance allows
+// external control of those features using CSS.
+const defaultIcon = '<svg viewBox="0 0 30 30"><path d="m 5 5 l 5 25 l 25 25 l 25 5 z"/></svg>';
+
+function validateSvgString(svgString) {
+  // We could do more validation here, but at least make sure we didn't
+  // get null, undefined, or the empty string.
+  return !!svgString;
+}
+
+const InlineSvgIconWidget = (props) => {
+  if (!validateSvgString(props.icon)) {
+    console.log(`InlineSvgIconWidget won't render, invalid icon property: ${props.icon}`);
+    return null;
+  }
+
+  const style = Object.assign({}, props.style, {
+    width: props.width,
+    height: props.height,
+  });
+
+  return (
+    <div
+      style={style}
+      className={props.className}
+      onClick={props.onClick}
+      dangerouslySetInnerHTML={{ __html: props.icon }}
+    />);
+};
+
+InlineSvgIconWidget.propTypes = {
+  className: React.PropTypes.string,
+  height: React.PropTypes.string,
+  icon: React.PropTypes.string,
+  width: React.PropTypes.string,
+  style: React.PropTypes.object,
+  onClick: React.PropTypes.func,
+};
+
+InlineSvgIconWidget.defaultProps = {
+  className: '',
+  icon: defaultIcon,
+  style: {},
+};
+
+export default InlineSvgIconWidget;


### PR DESCRIPTION
Having an option for doing svg icon widget inline, rather than "<use>"-ing the svg from a sprite, gives application code more ability to select and style the inner parts of the icon via CSS.