### PR TITLE
WIP: fix(SmartConnect): Propagate error in certain cases

### DIFF
--- a/src/IO/WebSocket/SmartConnect/index.js
+++ b/src/IO/WebSocket/SmartConnect/index.js
@@ -56,6 +56,13 @@ export default class SmartConnect {
         autobahnConnect(this);
       }));
       this.subscriptions.push(launcher.onError((data, envelope) => {
+        // Check if the launcher was present but returned some kind of error,
+        // in which case, we should propagate the error
+        if (envelope && envelope.topic && envelope.topic === 'launcher.error') {
+          this.errorForwarder(envelope.topic, envelope);
+          return;
+        }
+
         // Try to use standard connection URL
         this.config.sessionURL = DEFAULT_SESSION_URL;
         autobahnConnect(this);


### PR DESCRIPTION
If the problem was that there simply was no launcher, then we should try the standard connection url. 
 However, if the launcher was present and returned some error condition, then we should propagate that error back to the caller instead.