### PR TITLE
fix(webpack): loader tweak for svg-sprite-loader v2.0+

### DIFF
--- a/config/webpack.loaders.js
+++ b/config/webpack.loaders.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
     test: /\.svg$/,
-    loader: 'svg-sprite-loader',
+    loader: 'svg-sprite-loader?runtimeCompat=true',
     exclude: /fonts/,
   }, {
     test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,


### PR DESCRIPTION
Use backward-compatible flag. Works with 0.x versions too.