### PR TITLE
fix(CountToolbar): Add count toolbar, for selection provider

### DIFF
--- a/src/React/Widgets/CountToolbar/index.js
+++ b/src/React/Widgets/CountToolbar/index.js
@@ -1,0 +1,171 @@
+import React from 'react';
+
+import style from 'PVWStyle/ReactWidgets/CountToolbar.mcss';
+
+import { capitalize } from '../../../Common/Core/CompositeClosureHelper';
+
+const arrayZeros = n => Array(...Array(n)).map(Number.prototype.valueOf, 0);
+const arraySequence = n => Array(...Array(n)).map((d, i) => i);
+
+export default class CountToolbar extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const inScores = this.props.provider.getScores();
+    const numScores = inScores.length;
+    this.state = {
+      count: '',
+      total: this.props.provider.getDataRowCount(),
+      annotationType: 'empty',
+      annotationName: '',
+      scoreCounts: arrayZeros(numScores + 1),
+      activeScores: this.props.activeScores ? [].concat(this.props.activeScores) :
+        arraySequence(numScores + 1),
+      scores: inScores,
+      numScores,
+    };
+    this.state.scoreCounts[numScores] = this.state.total;
+
+    // Autobinding
+    // this.onActiveScoreChange = this.onActiveScoreChange.bind(this);
+    this.boxClick = this.boxClick.bind(this);
+  }
+
+  componentWillMount() {
+    this.subscriptions = [];
+    this.subscriptions.push(this.props.provider.subscribeToDataSelection('counts', (countData) => {
+      let count = 0;
+      let unselected = 0;
+      let total = 0;
+      const scoreCounts = arrayZeros(this.state.numScores + 1);
+      countData.forEach((item) => {
+        unselected += item.count;
+        scoreCounts[item.role.score] = item.count;
+        if (this.state.activeScores.indexOf(item.role.score) !== -1) {
+          count += item.count;
+        }
+        total = item.total;
+      });
+      unselected = total - unselected;
+      scoreCounts[scoreCounts.length - 1] = unselected;
+      this.setState({ count, scoreCounts, total });
+    }, [], { partitionScores: arraySequence(this.state.numScores) }));
+
+    const processAnnotation = (annotation) => {
+      if (!annotation) {
+        return;
+      }
+
+      const changeSet = {};
+      const annotationType = annotation.selection.type;
+      changeSet.annotationType = annotationType;
+      changeSet.annotationName = annotation.name ? annotation.name : '';
+
+      if (this.state.annotationType === 'partition' && annotationType !== 'partition') {
+        // Changing from partition to anything else, we re-activate everything
+        changeSet.activeScores = arraySequence(this.state.numScores + 1);
+      }
+
+      this.setState(changeSet);
+      if (changeSet.activeScores) {
+        this.notifyVisibilityChanged(changeSet.activeScores);
+      }
+    };
+
+    this.subscriptions.push(this.props.provider.onAnnotationChange(processAnnotation));
+    processAnnotation(this.props.provider.getAnnotation());
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.activeScores) {
+      this.setState({ activeScores: [].concat(nextProps.activeScores) });
+    }
+  }
+
+  componentWillUnmount() {
+    while (this.subscriptions.length) {
+      this.subscriptions.pop().unsubscribe();
+    }
+  }
+
+  notifyVisibilityChanged(activeScores) {
+    if (this.props.onChange) {
+      this.props.onChange(activeScores);
+    }
+  }
+
+  boxClick(event) {
+    const idx = Number(event.target.getAttribute('data-score'));
+
+    const changeSet = {};
+    if (this.state.activeScores.indexOf(idx) === -1) {
+      changeSet.activeScores = this.state.activeScores.concat(idx);
+    } else {
+      changeSet.activeScores = this.state.activeScores.filter(i => i !== idx);
+    }
+
+    let count = 0;
+    changeSet.activeScores.forEach((i) => {
+      count += this.state.scoreCounts[i] || 0;
+    });
+
+    changeSet.count = count;
+    this.setState(changeSet);
+    this.notifyVisibilityChanged(changeSet.activeScores);
+  }
+
+  render() {
+    return (
+      <div className={style.container}>
+        <div
+          className={style.activeAnnotationName}
+          title={`Active annotation: ${this.state.annotationName}`}
+        >{this.state.annotationName}</div>
+        <section className={style.scoreContainer} >
+          <div
+            className={this.state.activeScores.indexOf(this.state.numScores) !== -1 ? style.selectedScoreBlock : style.scoreBlock}
+            style={{
+              background: '#CCCCCC',
+              display: 'inline-block',
+            }}
+            title={`Total (${this.state.count} active)`}
+            data-score={`${this.state.numScores}`}
+            onClick={this.boxClick}
+          >{this.state.total}</div>
+          <div className={style.expressionOperator}>=</div>
+          {this.state.scores.map((score, idx) =>
+            <div key={`root-${idx}`} className={style.subBlock}>
+              <div
+                className={this.state.activeScores.indexOf(idx) !== -1 ? style.selectedScoreBlock : style.scoreBlock}
+                style={{
+                  background: score.color,
+                  display: 'inline-block',
+                }}
+                title={`"${capitalize(score.name)}" (${this.state.annotationType} annotation)`}
+                data-score={idx}
+                onClick={this.boxClick}
+              >{this.state.scoreCounts[idx]}
+              </div>
+              <div className={style.expressionOperator}>+</div>
+            </div>
+          )}
+          <div
+            className={style.selectedScoreBlock}
+            style={{
+              background: '',
+              display: 'inline-block',
+              border: '2px dashed black',
+              cursor: 'default',
+            }}
+            title={`Unselected (${this.state.annotationType} annotation)`}
+          >{this.state.scoreCounts[this.state.scoreCounts.length - 1]}</div>
+        </section>
+      </div>);
+  }
+}
+
+CountToolbar.propTypes = {
+  provider: React.PropTypes.object,
+  onChange: React.PropTypes.func,
+  activeScores: React.PropTypes.array,
+};

--- a/src/React/Widgets/ScatterPlotCameraControl/index.js
+++ b/src/React/Widgets/ScatterPlotCameraControl/index.js
@@ -21,7 +21,8 @@ export default class ScatterPlotCameraControl extends React.Component {
 
     // Rescale axis...
     this.resetCamera = () => {
-      this.props.manager.resetCamera(props.name);
+      // force a rescale/reset.
+      this.props.manager.resetCamera(props.name, true);
     };
 
     // Action mapping

--- a/src/React/Widgets/ScatterPlotControl/EditView.js
+++ b/src/React/Widgets/ScatterPlotControl/EditView.js
@@ -52,8 +52,10 @@ export default function EditView(props) {
 
   scores.forEach((scoreObj) => {
     scoreMap[scoreObj.name] = scoreObj.color;
-    ACTIVE_SCORE_MAPPING[scoreObj.name] = scoreObj.value;
+    ACTIVE_SCORE_MAPPING[scoreObj.name] = scoreObj.index;
   });
+  // unselected index is one beyond the scores indices.
+  ACTIVE_SCORE_MAPPING.unselected = scores.length;
 
   const functionPresets = [
     { icon: HighestBest, key: 'HighestBest' },
@@ -67,6 +69,7 @@ export default function EditView(props) {
     const scoreIdx = activeScores.indexOf(score);
     if (scoreIdx < 0) {
       activeScores.push(score);
+      activeScores.sort((a, b) => (a - b));
     } else {
       activeScores.splice(scoreIdx, 1);
     }
@@ -231,7 +234,7 @@ export default function EditView(props) {
           { Object.keys(ACTIVE_SCORE_MAPPING).map((scoreName, i) => (
             <div
               key={i}
-              className={activeScores.indexOf(scoreName) >= 0 ? style.colorLegendPatch : style.inactiveColorLegendPatch}
+              className={activeScores.indexOf(ACTIVE_SCORE_MAPPING[scoreName]) >= 0 ? style.colorLegendPatch : style.inactiveColorLegendPatch}
               onClick={toggleActiveScore(scoreName)}
               style={{
                 background: scoreMap[scoreName],

--- a/style/ReactWidgets/CountToolbar.mcss
+++ b/style/ReactWidgets/CountToolbar.mcss
@@ -1,0 +1,71 @@
+.container {
+  float: left;
+  font-size: 20px;
+  position: relative;
+}
+
+.count {
+  float: left;
+  font-size: 200%;
+  font-weight: bold;
+  line-height: 35px;
+  padding: 0 10px;
+  text-align: right;
+  min-width: 150px;
+  position: relative;
+}
+
+.scoreContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.expressionOperator {
+  flex: none;
+}
+
+.subBlock {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex: none;
+}
+
+.scoreBlock {
+  flex: none;
+  min-width: 30px;
+  height: 30px;
+  line-height: 30px;
+  box-sizing: content-box;
+  border-radius: 3px;
+  border: 2px solid gray;
+  margin: 2px;
+  opacity: 0.5;
+  text-align: center;
+  font-size: 15px;
+  font-weight: bold;
+  cursor: pointer;
+  user-select: none;
+  padding: 0 2px;
+}
+
+.selectedScoreBlock {
+  composes: scoreBlock;
+  opacity: 1;
+  border: 2px solid black;
+}
+
+.activeAnnotationName {
+  position: absolute;
+  font-size: x-small;
+  font-weight: bold;
+  color: grey;
+  top: -15px;
+  left: 3px;
+  cursor: default;
+  width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}

--- a/style/ReactWidgets/ScatterPlotControl.mcss
+++ b/style/ReactWidgets/ScatterPlotControl.mcss
@@ -194,8 +194,7 @@
 
 .userSelLegendEntry {
   float: left;
-  padding-left: 3px;
-  padding-top: 3px;
+  padding: 3px 2px 0 2px;
   font-weight: bold;
   font-size: smaller;
   margin-left: 5px;
@@ -206,7 +205,7 @@
 .colorLegendPatch {
   composes: userSelLegendEntry;
   flex: 1 0 auto;
-  width: 55px;
+  min-width: 36px;
   height: 25px;
   border-radius: 5px;
   border: 2px solid black;


### PR DESCRIPTION
Show the counts of scores in a selection, and toggle them,
via the selection provider.

Let Scatterplot handle activeScores correctly, too.