### PR TITLE
fix(Annotation): add config to show/hide uncertainty

### DIFF
--- a/src/InfoViz/Native/HistogramSelector/index.js
+++ b/src/InfoViz/Native/HistogramSelector/index.js
@@ -934,6 +934,8 @@ const DEFAULT_VALUES = {
   selectedDef: null,
 
   numberOfBins: 32,
+  // display UI for setting uncertainty at dividers.
+  showUncertainty: true,
 };
 
 // ----------------------------------------------------------------------------
@@ -943,8 +945,8 @@ export function extend(publicAPI, model, initialValues = {}) {
 
   CompositeClosureHelper.destroy(publicAPI, model);
   CompositeClosureHelper.isA(publicAPI, model, 'VizComponent');
-  CompositeClosureHelper.get(publicAPI, model, ['provider', 'container', 'numberOfBins']);
-  CompositeClosureHelper.set(publicAPI, model, ['numberOfBins']);
+  CompositeClosureHelper.get(publicAPI, model, ['provider', 'container', 'numberOfBins', 'showUncertainty']);
+  CompositeClosureHelper.set(publicAPI, model, ['numberOfBins', 'showUncertainty']);
   CompositeClosureHelper.dynamicArray(publicAPI, model, 'readOnlyFields');
 
   histogramSelector(publicAPI, model);

--- a/src/InfoViz/Native/HistogramSelector/score.js
+++ b/src/InfoViz/Native/HistogramSelector/score.js
@@ -764,6 +764,10 @@ export default function init(inPublicAPI, inModel) {
       .attr('type', 'number')
       .attr('step', 'any')
       .style('width', '6em');
+    if (!model.showUncertainty) {
+      // if we aren't supposed to show uncertainty, hide this row.
+      tr2.style('display', 'none');
+    }
     dPopupDiv
       .append('div').classed(style.scoreDashSpacer, true);
     dPopupDiv

--- a/src/React/ToggleTools/AnnotationEditor/index.js
+++ b/src/React/ToggleTools/AnnotationEditor/index.js
@@ -98,6 +98,7 @@ export default class AnnotationEditorTool extends React.Component {
               ranges={this.state.ranges}
               onChange={this.onAnnotationChange}
               getLegend={this.props.provider.getLegend}
+              showUncertainty={this.props.showUncertainty}
             />
           </div>
         </OverlayWindow>
@@ -108,6 +109,7 @@ export default class AnnotationEditorTool extends React.Component {
 AnnotationEditorTool.propTypes = {
   provider: React.PropTypes.object,
   size: React.PropTypes.string,
+  showUncertainty: React.PropTypes.bool,
 
   activeWindow: React.PropTypes.object,
   onActiveWindow: React.PropTypes.func,
@@ -115,4 +117,5 @@ AnnotationEditorTool.propTypes = {
 
 AnnotationEditorTool.defaultProps = {
   size: '35px',
+  showUncertainty: true,
 };

--- a/src/React/Widgets/AnnotationEditorWidget/ManyScore/index.js
+++ b/src/React/Widgets/AnnotationEditorWidget/ManyScore/index.js
@@ -29,6 +29,7 @@ export default function render(props) {
           ranges={props.ranges}
           getLegend={props.getLegend}
           onChange={props.onSelectionChange}
+          showUncertainty={props.showUncertainty}
         >
           {props.annotation.score.map((score, idx, array) =>
             <BGSelector
@@ -92,6 +93,7 @@ render.propTypes = {
   ranges: React.PropTypes.object,
   getLegend: React.PropTypes.func,
   rationaleOpen: React.PropTypes.bool,
+  showUncertainty: React.PropTypes.bool,
 
   onSelectionChange: React.PropTypes.func,
   onAnnotationChange: React.PropTypes.func,
@@ -100,4 +102,5 @@ render.propTypes = {
 
 render.defaultProps = {
   rationaleOpen: false,
+  showUncertainty: true,
 };

--- a/src/React/Widgets/AnnotationEditorWidget/OneScore/index.js
+++ b/src/React/Widgets/AnnotationEditorWidget/OneScore/index.js
@@ -75,6 +75,7 @@ render.propTypes = {
   ranges: React.PropTypes.object,
   getLegend: React.PropTypes.func,
   rationaleOpen: React.PropTypes.bool,
+  showUncertainty: React.PropTypes.bool,
 
   onSelectionChange: React.PropTypes.func,
   onAnnotationChange: React.PropTypes.func,
@@ -83,4 +84,5 @@ render.propTypes = {
 
 render.defaultProps = {
   rationaleOpen: false,
+  showUncertainty: true,
 };

--- a/src/React/Widgets/AnnotationEditorWidget/index.js
+++ b/src/React/Widgets/AnnotationEditorWidget/index.js
@@ -92,9 +92,11 @@ render.propTypes = {
   onChange: React.PropTypes.func,
   getLegend: React.PropTypes.func,
   rationaleOpen: React.PropTypes.bool,
+  showUncertainty: React.PropTypes.bool,
 };
 
 render.defaultProps = {
   onChange(annotation, isEditDone) {},
   rationaleOpen: false,
+  showUncertainty: true,
 };

--- a/src/React/Widgets/AnnotationStoreEditorWidget/index.js
+++ b/src/React/Widgets/AnnotationStoreEditorWidget/index.js
@@ -69,6 +69,7 @@ export default function render(props) {
             getLegend={props.getLegend}
             onChange={props.onAnnotationChange}
             rationaleOpen={props.rationaleOpen}
+            showUncertainty={props.showUncertainty}
           />
         </section>
       </div>
@@ -91,6 +92,7 @@ render.propTypes = {
   ranges: React.PropTypes.object,
   getLegend: React.PropTypes.func,
   rationaleOpen: React.PropTypes.bool,
+  showUncertainty: React.PropTypes.bool,
   ignoreGeneration: React.PropTypes.bool,
 
   onAnnotationChange: React.PropTypes.func,
@@ -101,5 +103,6 @@ render.defaultProps = {
   onAnnotationChange(annotation, isEditing) {},
   onChange(action, id, annotation) {},
   rationaleOpen: false,
+  showUncertainty: true,
   ignoreGeneration: false,
 };

--- a/src/React/Widgets/SelectionEditorWidget/partition/DividerRender.js
+++ b/src/React/Widgets/SelectionEditorWidget/partition/DividerRender.js
@@ -70,7 +70,7 @@ export default function render(props) {
         onChange={onChange}
         onBlur={onBlur}
       />
-      {(divider.uncertainty !== undefined) ? (
+      {(divider.uncertainty !== undefined && props.showUncertainty) ? (
         <span>
           {/* plus-minus unicode character: &#xb1; */}
           <div className={style.inequality}>&#xb1;
@@ -97,4 +97,5 @@ render.propTypes = {
   path: React.PropTypes.array,
   onChange: React.PropTypes.func,
   onDelete: React.PropTypes.func,
+  showUncertainty: React.PropTypes.bool,
 };

--- a/src/React/Widgets/SelectionEditorWidget/partition/index.js
+++ b/src/React/Widgets/SelectionEditorWidget/partition/index.js
@@ -92,6 +92,7 @@ export default function render(props) {
             path={['dividers', idx]}
             key={idx}
             getLegend={props.getLegend}
+            showUncertainty={props.showUncertainty}
           />
         )}
       </FieldRender>
@@ -105,5 +106,9 @@ render.propTypes = {
   onChange: React.PropTypes.func,
   getLegend: React.PropTypes.func,
   className: React.PropTypes.string,
+  showUncertainty: React.PropTypes.bool,
 };
 
+render.defaultProps = {
+  showUncertainty: true,
+};


### PR DESCRIPTION
Partition annotation dividers can have uncertainty. Make the UI
for editing the uncertainty optional, so dividers keep the default
uncertainty of zero.