### PR TITLE
fix(ProxyEditorWidget): Reduce toolbar height from container height

### DIFF
--- a/style/ReactWidgets/ProxyEditorWidget.mcss
+++ b/style/ReactWidgets/ProxyEditorWidget.mcss
@@ -4,7 +4,7 @@
   justify-content: flex-start;
   align-items: stretch;
   box-sizing: border-box;
-  max-height: 100%;
+  max-height: calc(100% - 30px);
 }
 
 .contentContainer {


### PR DESCRIPTION
Fixes https://github.com/Kitware/pv-web-viewer/issues/15. Tested on Chromium and Firefox.