### PR TITLE
fix(deps): Add gl-matrix to deps to insist on 2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,23 +30,23 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-            "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.46.tgz",
+            "integrity": "sha512-7BKRkmYaPZm3Yff5HGZJKCz7RqZ5jUjknsXT6Gz5YKG23J3uq9hAj0epncCB0rlqmnZ8Q+UUpQB2tCR5mT37vw==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0-beta.44"
+                "@babel/highlight": "7.0.0-beta.46"
             }
         },
         "@babel/generator": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.46.tgz",
+            "integrity": "sha512-5VfaEVkPG0gpNSTcf70jvV+MjbMoNn4g2iluwM7MhciedkolEtmG7PcdoUj5W1EmMfngz5cF65V7UMZXJO6y8Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.44",
+                "@babel/types": "7.0.0-beta.46",
                 "jsesc": "2.5.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
             },
@@ -60,41 +60,41 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-            "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.46.tgz",
+            "integrity": "sha512-zm4Kc5XB2njGs8PkmjV1zE/g1hBuphbh+VcDyFLaQsxkxSFSUtCbKwFL8AQpL/qPIcGbvX1MBt50a/3ZZH2CQA==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "7.0.0-beta.44",
-                "@babel/template": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44"
+                "@babel/helper-get-function-arity": "7.0.0-beta.46",
+                "@babel/template": "7.0.0-beta.46",
+                "@babel/types": "7.0.0-beta.46"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz",
+            "integrity": "sha512-dPrTb7QHVx44xJLjUl3LGAc13iS7hdXdO0fiOxdRN1suIS91yGGgeuwiQBlrw5SxbFchYtwenhlKbqHdVfGyVA==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.44"
+                "@babel/types": "7.0.0-beta.46"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-            "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.46.tgz",
+            "integrity": "sha512-UT7acgV7wsnBPwnqslqcnUFvsPBP4TtVaYM82xPGA7+evAa8q8HXOmFk08qsMK/pX/yy4+51gJJwyw2zofnacA==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0-beta.44"
+                "@babel/types": "7.0.0-beta.46"
             }
         },
         "@babel/highlight": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-            "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.46.tgz",
+            "integrity": "sha512-r4snW6Q8ICL3Y8hGzYJRvyG/+sc+kvkewXNedG9tQjoHmUFMwMSv/o45GWQUQswevGnWghiGkpRPivFfOuMsOA==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "esutils": "2.0.2",
                 "js-tokens": "3.0.2"
             },
@@ -109,14 +109,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -126,9 +126,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -137,65 +137,65 @@
             }
         },
         "@babel/template": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-            "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.46.tgz",
+            "integrity": "sha512-3/qi4m0l6G/vZbEwtqfzJk73mYtuE7nvAO1zT3/ZrTAHy4sHf2vaF9Eh1w+Tau263Yrkh0bjVQPb9zw6G+GeMQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
-                "lodash": "4.17.5"
+                "@babel/code-frame": "7.0.0-beta.46",
+                "@babel/types": "7.0.0-beta.46",
+                "babylon": "7.0.0-beta.46",
+                "lodash": "4.17.10"
             },
             "dependencies": {
                 "babylon": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+                    "version": "7.0.0-beta.46",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+                    "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg==",
                     "dev": true
                 }
             }
         },
         "@babel/traverse": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-            "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.46.tgz",
+            "integrity": "sha512-IU7MTGbcjpfhf5tyCu3sDB7sWYainZQcT+CqOBdVZXZfq5MMr130R7aiZBI2g5dJYUaW1PS81DVNpd0/Sq/Gzg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/generator": "7.0.0-beta.44",
-                "@babel/helper-function-name": "7.0.0-beta.44",
-                "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
+                "@babel/code-frame": "7.0.0-beta.46",
+                "@babel/generator": "7.0.0-beta.46",
+                "@babel/helper-function-name": "7.0.0-beta.46",
+                "@babel/helper-split-export-declaration": "7.0.0-beta.46",
+                "@babel/types": "7.0.0-beta.46",
+                "babylon": "7.0.0-beta.46",
                 "debug": "3.1.0",
-                "globals": "11.4.0",
+                "globals": "11.5.0",
                 "invariant": "2.2.4",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             },
             "dependencies": {
                 "babylon": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+                    "version": "7.0.0-beta.46",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+                    "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg==",
                     "dev": true
                 },
                 "globals": {
-                    "version": "11.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-                    "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+                    "version": "11.5.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+                    "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
                     "dev": true
                 }
             }
         },
         "@babel/types": {
-            "version": "7.0.0-beta.44",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-            "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+            "version": "7.0.0-beta.46",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.46.tgz",
+            "integrity": "sha512-uA5aruF2KKsJxToWdDpftsrPOIQtoGrGno2hiaeO9JRvfT9xZdK11nPoC+/RF9emNzmNbWn4HCRdCY+McT5Nbw==",
             "dev": true,
             "requires": {
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "to-fast-properties": "2.0.0"
             },
             "dependencies": {
@@ -218,9 +218,9 @@
             }
         },
         "@octokit/rest": {
-            "version": "15.2.6",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.2.6.tgz",
-            "integrity": "sha512-KcqG0zjnjzUqn7wczz/fKiueNpTLiAI7erhUG6bXWAsYKJJlqnwYonFSXrMW/nmes5y+qOk4uSyHBh1mdRXdVQ==",
+            "version": "15.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.5.0.tgz",
+            "integrity": "sha512-7+UQVYO3t2JRTo9UAIEwO4Gw7Zr+ClTzJnopICe0zsn5zWUGb6vMcVTA057j656gJdN3zPG1N0l4NpsZsZGPDw==",
             "dev": true,
             "requires": {
                 "before-after-hook": "1.1.0",
@@ -228,40 +228,11 @@
                 "debug": "3.1.0",
                 "http-proxy-agent": "2.1.0",
                 "https-proxy-agent": "2.2.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "node-fetch": "2.1.2",
                 "url-template": "2.0.8"
             },
             "dependencies": {
-                "agent-base": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-                    "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
-                    "dev": true,
-                    "requires": {
-                        "es6-promisify": "5.0.0"
-                    }
-                },
-                "http-proxy-agent": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-                    "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
-                    }
-                },
-                "https-proxy-agent": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-                    "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
-                    "dev": true,
-                    "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
-                    }
-                },
                 "node-fetch": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
@@ -278,7 +249,7 @@
             "requires": {
                 "d3-array": "1.2.1",
                 "d3-collection": "1.0.4",
-                "d3-interpolate": "1.1.6"
+                "d3-interpolate": "1.2.0"
             }
         },
         "@semantic-release/commit-analyzer": {
@@ -287,11 +258,11 @@
             "integrity": "sha512-4GLFDmp8Up+f4GQGPIzLVd8X9a3yqbZjl761sEdfCH4e5FkEO3I9XRlTEfKSueeCt5OA1lZBb9IHGpZ6Ot0+BQ==",
             "dev": true,
             "requires": {
-                "conventional-changelog-angular": "3.0.6",
+                "conventional-changelog-angular": "3.0.7",
                 "conventional-commits-parser": "2.1.7",
                 "debug": "3.1.0",
                 "import-from": "2.1.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "@semantic-release/error": {
@@ -301,31 +272,31 @@
             "dev": true
         },
         "@semantic-release/github": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-4.2.11.tgz",
-            "integrity": "sha512-iaoHp8sDTgE0dFK4l9UwtjP/GmxHN9r8Hxi8fJNXOtC6tYU8JJqbvQHek4N7flNNbx74Drgga+Sc1eShlhE3Ng==",
+            "version": "4.2.16",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-4.2.16.tgz",
+            "integrity": "sha512-SuaBvUf7l3RwqdxBKyRSPZnSckEMB0EqBu6658x41hivJXn7KdJnH/EcKNzMeKu8zFJ6a8DrXTY71APVKE3wHg==",
             "dev": true,
             "requires": {
-                "@octokit/rest": "15.2.6",
+                "@octokit/rest": "15.5.0",
                 "@semantic-release/error": "2.2.0",
                 "aggregate-error": "1.0.0",
                 "bottleneck": "2.3.0",
                 "debug": "3.1.0",
-                "fs-extra": "5.0.0",
+                "fs-extra": "6.0.1",
                 "globby": "8.0.1",
-                "issue-parser": "1.0.3",
-                "lodash": "4.17.5",
+                "issue-parser": "2.0.0",
+                "lodash": "4.17.10",
                 "mime": "2.3.1",
                 "p-filter": "1.0.0",
-                "p-retry": "1.0.0",
+                "p-retry": "2.0.0",
                 "parse-github-url": "1.0.2",
                 "url-join": "4.0.0"
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-                    "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+                    "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "4.1.11",
@@ -341,9 +312,9 @@
                     "requires": {
                         "array-union": "1.0.2",
                         "dir-glob": "2.0.0",
-                        "fast-glob": "2.2.0",
+                        "fast-glob": "2.2.1",
                         "glob": "7.1.2",
-                        "ignore": "3.3.7",
+                        "ignore": "3.3.8",
                         "pify": "3.0.0",
                         "slash": "1.0.0"
                     }
@@ -372,16 +343,16 @@
             }
         },
         "@semantic-release/npm": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-3.2.4.tgz",
-            "integrity": "sha512-Kkl5nwRGw0yRg6B4qr8LIi+BkcdK3tJ67ziTzo65SZLEpuV8NLVsm7OAiOMK34rOL3Utkno+BA3AGTg7fhm/nw==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-3.2.5.tgz",
+            "integrity": "sha512-I40tCW1S3QY4hStrg5PGnRI7Y8N5XVnsG9grEkEKSZmcuBPWC1ag5YcSPxnlsOzbsb94wRPwJTKuzNo7/nA2iQ==",
             "dev": true,
             "requires": {
                 "@semantic-release/error": "2.2.0",
                 "aggregate-error": "1.0.0",
                 "execa": "0.10.0",
-                "fs-extra": "5.0.0",
-                "lodash": "4.17.5",
+                "fs-extra": "6.0.1",
+                "lodash": "4.17.10",
                 "nerf-dart": "1.0.0",
                 "normalize-url": "2.0.1",
                 "read-pkg": "3.0.0",
@@ -389,9 +360,9 @@
             },
             "dependencies": {
                 "fs-extra": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-                    "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+                    "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "4.1.11",
@@ -502,20 +473,32 @@
             }
         },
         "@semantic-release/release-notes-generator": {
-            "version": "6.0.9",
-            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.9.tgz",
-            "integrity": "sha512-qK9d4m4QoK5kqZ/QU0hwDIdaIj0FttsActLAAH87FrqJYJZCikMrgrpzkLM8YFpgi6MZCew9YirGVrwvmxXUVg==",
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.10.tgz",
+            "integrity": "sha512-8eigxfGSy36+mv4rUIbGZAGZkUVZYNXOyRpcG+ZHSeGTqG6hu9uUxmzkfQ2hvK3zSxqrzKPg3MxnhvZL1Qqmrg==",
             "dev": true,
             "requires": {
-                "conventional-changelog-angular": "3.0.6",
+                "conventional-changelog-angular": "3.0.7",
                 "conventional-changelog-writer": "3.0.9",
                 "conventional-commits-parser": "2.1.7",
                 "debug": "3.1.0",
                 "get-stream": "3.0.0",
-                "git-url-parse": "8.3.1",
+                "git-url-parse": "9.0.0",
                 "import-from": "2.1.0",
                 "into-stream": "3.1.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
+            },
+            "dependencies": {
+                "git-url-parse": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-9.0.0.tgz",
+                    "integrity": "sha512-zks1jS4ocMA/9WUx3C0nGIj/wBQjjIuktQ4KqKTyStMdEtnnFbZ4ZVKCvNeHwKh1COk/8sZaVTyvYj3paHI9Fg==",
+                    "dev": true,
+                    "requires": {
+                        "git-up": "2.0.10",
+                        "parse-domain": "2.0.0"
+                    }
+                }
             }
         },
         "@sindresorhus/is": {
@@ -525,9 +508,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "9.6.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.4.tgz",
-            "integrity": "sha512-Awg4BcUYiZtNKoveGOu654JVPt11V/KIC77iBz8NweyoOAZpz5rUJfPDwwD+ajfTs2HndbTCEB8IuLfX9m/mmw==",
+            "version": "10.0.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.0.9.tgz",
+            "integrity": "sha512-ekJ3mXJcJP+Nn5kC6eCmWPND/fHx/Ga12Lz0IJgTfGz1ge7OCIR5xcDY5tcYgnyM1kWsVDRH2bguxkGcNj39AQ==",
             "dev": true
         },
         "JSONStream": {
@@ -637,23 +620,6 @@
                 }
             }
         },
-        "acorn5-object-spread": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/acorn5-object-spread/-/acorn5-object-spread-4.0.0.tgz",
-            "integrity": "sha1-1XWAge7ZcSGrC+R+Mcqu8qo5lpc=",
-            "dev": true,
-            "requires": {
-                "acorn": "5.5.3"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "5.5.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
-                    "dev": true
-                }
-            }
-        },
         "add-line-numbers": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
@@ -686,21 +652,12 @@
             "dev": true
         },
         "agent-base": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-            "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+            "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "semver": "5.0.3"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.0.3",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-                    "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-                    "dev": true
-                }
+                "es6-promisify": "5.0.0"
             }
         },
         "aggregate-error": {
@@ -810,7 +767,7 @@
                 "bluebird": "3.5.1",
                 "buffer-more-ints": "0.0.2",
                 "readable-stream": "1.1.14",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             },
             "dependencies": {
                 "isarray": {
@@ -1089,23 +1046,6 @@
                 "array-bounds": "1.0.1"
             }
         },
-        "array-pack-2d": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/array-pack-2d/-/array-pack-2d-0.1.1.tgz",
-            "integrity": "sha1-vb3PL3+xm/uOBvvwHYvIxmS0aT0=",
-            "dev": true,
-            "requires": {
-                "dtype": "1.0.0"
-            },
-            "dependencies": {
-                "dtype": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/dtype/-/dtype-1.0.0.tgz",
-                    "integrity": "sha1-rjT/ooJnNxUgNYLWG73QqtPLo+c=",
-                    "dev": true
-                }
-            }
-        },
         "array-range": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
@@ -1229,13 +1169,12 @@
             }
         },
         "async": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-            "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "dev": true,
-            "optional": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "async-each": {
@@ -1257,9 +1196,9 @@
             "dev": true
         },
         "atob": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-            "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+            "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
             "dev": true
         },
         "atob-lite": {
@@ -1274,11 +1213,11 @@
             "integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
             "dev": true,
             "requires": {
-                "browserslist": "3.2.4",
-                "caniuse-lite": "1.0.30000827",
+                "browserslist": "3.2.7",
+                "caniuse-lite": "1.0.30000840",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
-                "postcss": "6.0.21",
+                "postcss": "6.0.22",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -1343,7 +1282,7 @@
                 "convert-source-map": "1.5.1",
                 "debug": "2.6.9",
                 "json5": "0.5.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "minimatch": "3.0.4",
                 "path-is-absolute": "1.0.1",
                 "private": "0.1.8",
@@ -1370,22 +1309,22 @@
         },
         "babel-eslint": {
             "version": "8.2.2",
-            "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
             "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.44",
-                "@babel/traverse": "7.0.0-beta.44",
-                "@babel/types": "7.0.0-beta.44",
-                "babylon": "7.0.0-beta.44",
+                "@babel/code-frame": "7.0.0-beta.46",
+                "@babel/traverse": "7.0.0-beta.46",
+                "@babel/types": "7.0.0-beta.46",
+                "babylon": "7.0.0-beta.46",
                 "eslint-scope": "3.7.1",
                 "eslint-visitor-keys": "1.0.0"
             },
             "dependencies": {
                 "babylon": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+                    "version": "7.0.0-beta.46",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+                    "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg==",
                     "dev": true
                 }
             }
@@ -1401,7 +1340,7 @@
                 "babel-types": "6.26.0",
                 "detect-indent": "4.0.0",
                 "jsesc": "1.3.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "source-map": "0.5.7",
                 "trim-right": "1.0.1"
             }
@@ -1460,7 +1399,7 @@
                 "babel-helper-function-name": "6.24.1",
                 "babel-runtime": "6.26.0",
                 "babel-types": "6.26.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-helper-explode-assignable-expression": {
@@ -1537,7 +1476,7 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "babel-types": "6.26.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-helper-remap-async-to-generator": {
@@ -1788,7 +1727,7 @@
                 "babel-template": "6.26.0",
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -1872,15 +1811,15 @@
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
                 "babel-runtime": "6.26.0",
                 "babel-template": "6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-            "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+            "version": "6.26.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+            "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
             "dev": true,
             "requires": {
                 "babel-plugin-transform-strict-mode": "6.24.1",
@@ -2101,14 +2040,14 @@
             "dev": true,
             "requires": {
                 "babel-runtime": "6.26.0",
-                "core-js": "2.5.5",
+                "core-js": "2.5.6",
                 "regenerator-runtime": "0.10.5"
             },
             "dependencies": {
                 "core-js": {
-                    "version": "2.5.5",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-                    "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+                    "version": "2.5.6",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+                    "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
                     "dev": true
                 },
                 "regenerator-runtime": {
@@ -2139,7 +2078,7 @@
                 "babel-plugin-transform-es2015-function-name": "6.24.1",
                 "babel-plugin-transform-es2015-literals": "6.22.0",
                 "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
                 "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
                 "babel-plugin-transform-es2015-modules-umd": "6.24.1",
                 "babel-plugin-transform-es2015-object-super": "6.24.1",
@@ -2163,8 +2102,8 @@
                     "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "1.0.30000827",
-                        "electron-to-chromium": "1.3.42"
+                        "caniuse-lite": "1.0.30000840",
+                        "electron-to-chromium": "1.3.45"
                     }
                 }
             }
@@ -2187,7 +2126,7 @@
                 "babel-plugin-transform-es2015-function-name": "6.24.1",
                 "babel-plugin-transform-es2015-literals": "6.22.0",
                 "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
                 "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
                 "babel-plugin-transform-es2015-modules-umd": "6.24.1",
                 "babel-plugin-transform-es2015-object-super": "6.24.1",
@@ -2268,17 +2207,17 @@
             "requires": {
                 "babel-core": "6.26.0",
                 "babel-runtime": "6.26.0",
-                "core-js": "2.5.5",
+                "core-js": "2.5.6",
                 "home-or-tmp": "2.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "mkdirp": "0.5.1",
                 "source-map-support": "0.4.18"
             },
             "dependencies": {
                 "core-js": {
-                    "version": "2.5.5",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-                    "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+                    "version": "2.5.6",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+                    "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
                     "dev": true
                 }
             }
@@ -2289,14 +2228,14 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.5",
+                "core-js": "2.5.6",
                 "regenerator-runtime": "0.11.1"
             },
             "dependencies": {
                 "core-js": {
-                    "version": "2.5.5",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-                    "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+                    "version": "2.5.6",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+                    "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
                     "dev": true
                 }
             }
@@ -2311,7 +2250,7 @@
                 "babel-traverse": "6.26.0",
                 "babel-types": "6.26.0",
                 "babylon": "6.18.0",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "babel-traverse": {
@@ -2328,7 +2267,7 @@
                 "debug": "2.6.9",
                 "globals": "9.18.0",
                 "invariant": "2.2.4",
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             },
             "dependencies": {
                 "debug": {
@@ -2350,7 +2289,7 @@
             "requires": {
                 "babel-runtime": "6.26.0",
                 "esutils": "2.0.2",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "to-fast-properties": "1.0.3"
             }
         },
@@ -2603,9 +2542,9 @@
             "dev": true
         },
         "body-parser": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-            "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
@@ -2613,10 +2552,10 @@
                 "debug": "2.6.9",
                 "depd": "1.1.2",
                 "http-errors": "1.6.3",
-                "iconv-lite": "0.4.19",
+                "iconv-lite": "0.4.23",
                 "on-finished": "2.3.0",
-                "qs": "6.5.1",
-                "raw-body": "2.3.2",
+                "qs": "6.5.2",
+                "raw-body": "2.3.3",
                 "type-is": "1.6.16"
             },
             "dependencies": {
@@ -2756,8 +2695,8 @@
             "dev": true,
             "requires": {
                 "quote-stream": "1.0.2",
-                "resolve": "1.7.0",
-                "static-module": "2.2.4",
+                "resolve": "1.7.1",
+                "static-module": "2.2.5",
                 "through2": "2.0.3"
             },
             "dependencies": {
@@ -2812,15 +2751,15 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
                 },
                 "static-module": {
-                    "version": "2.2.4",
-                    "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.4.tgz",
-                    "integrity": "sha512-qlzhn8tYcfLsXK2RTWtkx1v/cqiPtS9eFy+UmQ9UnpEDYcwtgbceOybnKp5JncsOnLI/pyGeyzI9Bej9tv0xiA==",
+                    "version": "2.2.5",
+                    "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+                    "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
                     "dev": true,
                     "requires": {
                         "concat-stream": "1.6.2",
@@ -2845,7 +2784,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -2865,7 +2804,7 @@
                 "JSONStream": "1.3.2",
                 "combine-source-map": "0.8.0",
                 "defined": "1.0.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "through2": "2.0.3",
                 "umd": "3.0.3"
             }
@@ -2925,11 +2864,11 @@
                 "querystring-es3": "0.2.1",
                 "read-only-stream": "2.0.0",
                 "readable-stream": "2.0.6",
-                "resolve": "1.7.0",
+                "resolve": "1.7.1",
                 "shasum": "1.0.2",
                 "shell-quote": "1.6.1",
                 "stream-browserify": "2.0.1",
-                "stream-http": "2.8.1",
+                "stream-http": "2.8.2",
                 "string_decoder": "1.0.3",
                 "subarg": "1.0.0",
                 "syntax-error": "1.4.0",
@@ -2948,7 +2887,7 @@
                     "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -2964,7 +2903,7 @@
                 "create-hash": "1.2.0",
                 "evp_bytestokey": "1.0.3",
                 "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-cipher": {
@@ -3024,13 +2963,13 @@
             }
         },
         "browserslist": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.4.tgz",
-            "integrity": "sha512-Dwe62y/fNAcMfknzGJnkh7feISrrN0SmRvMFozb+Y2+qg7rfTIH5MS8yHzaIXcEWl8fPeIcdhZNQi1Lux+7dlg==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.7.tgz",
+            "integrity": "sha512-oYVLxFVqpX9uMhOIQBLtZL+CX4uY8ZpWcjNTaxyWl5rO8yA9SSNikFnAfvk8J3P/7z3BZwNmEqFKaJoYltj3MQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000827",
-                "electron-to-chromium": "1.3.42"
+                "caniuse-lite": "1.0.30000840",
+                "electron-to-chromium": "1.3.45"
             }
         },
         "btoa-lite": {
@@ -3040,19 +2979,19 @@
             "dev": true
         },
         "buble": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/buble/-/buble-0.18.0.tgz",
-            "integrity": "sha512-U3NJxUiSz0H1EB54PEHAuBTxdXgQH4DaQkvkINFXf9kEKCDWSn67EgQfFKbkTzsok4xRrIPsoxWDl2czCHR65g==",
+            "version": "0.19.3",
+            "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.3.tgz",
+            "integrity": "sha512-3B0Lcy2u6x6km0BqTz/FS3UnrOJlnIlBWsyjvtqzdtmWkqiS0+Sg4hc6L9Mmm63hZKTACpYS9vUeIoKSi1vcrQ==",
             "dev": true,
             "requires": {
                 "acorn": "5.5.3",
-                "acorn-jsx": "3.0.1",
-                "acorn5-object-spread": "4.0.0",
-                "chalk": "2.3.2",
+                "acorn-dynamic-import": "3.0.0",
+                "acorn-jsx": "4.1.1",
+                "chalk": "2.4.1",
                 "magic-string": "0.22.5",
                 "minimist": "1.2.0",
                 "os-homedir": "1.0.2",
-                "vlq": "0.2.3"
+                "vlq": "1.0.0"
             },
             "dependencies": {
                 "acorn": {
@@ -3060,6 +2999,15 @@
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
                     "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
                     "dev": true
+                },
+                "acorn-jsx": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+                    "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "5.5.3"
+                    }
                 },
                 "ansi-styles": {
                     "version": "3.2.1",
@@ -3071,14 +3019,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -3088,9 +3036,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -3099,12 +3047,12 @@
             }
         },
         "bubleify": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.1.0.tgz",
-            "integrity": "sha512-9FtUiQong0qiDuN/iOtDwqovyDXENTpcvQH9Szyc/wzALPt0tDdP1moIjJqeT5LMwLzvLkMHaL+RohWEeHY6XQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.0.tgz",
+            "integrity": "sha512-SJnUsR+f8WeDw0K2l1S+VuYI33Cu5Gfghe5jTow/fpJueNtnwyoECyfCGsDuFoQt4QGhjpV3LYPpN0hxy90LgA==",
             "dev": true,
             "requires": {
-                "buble": "0.18.0"
+                "buble": "0.19.3"
             }
         },
         "buffer": {
@@ -3191,7 +3139,7 @@
                 "chownr": "1.0.1",
                 "glob": "7.1.2",
                 "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "mississippi": "2.0.0",
                 "mkdirp": "0.5.1",
                 "move-concurrently": "1.0.1",
@@ -3202,16 +3150,6 @@
                 "y18n": "4.0.0"
             },
             "dependencies": {
-                "lru-cache": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-                    "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
-                    }
-                },
                 "y18n": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
@@ -3320,7 +3258,7 @@
             "requires": {
                 "core-js": "2.3.0",
                 "deep-equal": "1.0.1",
-                "espurify": "1.7.0",
+                "espurify": "1.8.0",
                 "estraverse": "4.2.0"
             }
         },
@@ -3384,7 +3322,7 @@
             "dev": true,
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000827",
+                "caniuse-db": "1.0.30000840",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
             },
@@ -3395,8 +3333,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000827",
-                        "electron-to-chromium": "1.3.42"
+                        "caniuse-db": "1.0.30000840",
+                        "electron-to-chromium": "1.3.45"
                     }
                 },
                 "lodash.memoize": {
@@ -3408,15 +3346,15 @@
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000827",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000827.tgz",
-            "integrity": "sha1-vSg53Rlgk7RMKMF/k1ExQMnZJYg=",
+            "version": "1.0.30000840",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000840.tgz",
+            "integrity": "sha1-aNWg8GlMkhgLDYLnINcPjmE2ZgQ=",
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30000827",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000827.tgz",
-            "integrity": "sha512-j9Q9hP5AhqOARNP6fLdctr3XrGhF921sBSycudf4E+8RCWpFT3rJdTfp/5o8LDp6p0NJTpYWEpBFiM+QEDzA6g==",
+            "version": "1.0.30000840",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000840.tgz",
+            "integrity": "sha512-Lw6AaouV6lh7TgIdQtLiUFKKO2mtDnZFkzCq5/V6tqs4ZI0OGVSDCEt1uegZ3OOBEBUYuVw3Hhr9DQSbgVofFA==",
             "dev": true
         },
         "canvas-fit": {
@@ -3523,7 +3461,7 @@
             "requires": {
                 "anymatch": "1.3.2",
                 "async-each": "1.0.1",
-                "fsevents": "1.1.3",
+                "fsevents": "1.2.3",
                 "glob-parent": "2.0.0",
                 "inherits": "2.0.3",
                 "is-binary-path": "1.0.1",
@@ -3539,9 +3477,9 @@
             "dev": true
         },
         "chrome-trace-event": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.2.tgz",
-            "integrity": "sha1-kPNohdU0WlBiEzLwcXtZWIPV2YI=",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
+            "integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A==",
             "dev": true
         },
         "ci-job-number": {
@@ -3557,13 +3495,13 @@
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "circular-json": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.1.tgz",
-            "integrity": "sha512-UjgcRlTAhAkLeXmDe2wK7ktwy/tgAqxiSndTIPiFZuIPLZmzHzWMwUIe9h9m/OokypG7snxCDEuwJshGBdPvaw==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.4.tgz",
+            "integrity": "sha512-vnJA8KS0BfOihugYEUkLRcnmq21FbuivbxgzDLXNs3zIk4KllV4Mx4UuTzBXht9F00C7QfD1YqMXg1zP6EXpig==",
             "dev": true
         },
         "circumcenter": {
@@ -3782,7 +3720,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -3793,7 +3731,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -3810,7 +3748,7 @@
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "dev": true,
             "requires": {
-                "q": "1.4.1"
+                "q": "1.5.1"
             }
         },
         "code-point-at": {
@@ -3937,9 +3875,9 @@
             }
         },
         "colors": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-            "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+            "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
             "dev": true
         },
         "combine-lists": {
@@ -3948,7 +3886,7 @@
             "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "combine-source-map": {
@@ -4171,6 +4109,12 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "dev": true
                 }
             }
         },
@@ -4183,7 +4127,7 @@
                 "cacache": "10.0.4",
                 "find-cache-dir": "1.0.0",
                 "neo-async": "2.5.1",
-                "serialize-javascript": "1.4.0",
+                "serialize-javascript": "1.5.0",
                 "webpack-sources": "1.1.0"
             }
         },
@@ -4272,21 +4216,13 @@
             "dev": true
         },
         "conventional-changelog-angular": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-3.0.6.tgz",
-            "integrity": "sha512-jWuwQEOn/jcPZ5ZQbAlKnrMAW00uT8BTac/ex1S2lDhqg5D4Qr3rGzyGmK/ZCSmVopE9BOcFkt3+ubEGqfpT9w==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-3.0.7.tgz",
+            "integrity": "sha512-I1W7Vr/2AFlwhrjvjhp8Tz61qsRWc/dL96kgMmAwkJw/eVLLTokbuYnyYQ8k+/Loy2na8C18yD0SOkE/1AmIsw==",
             "dev": true,
             "requires": {
                 "compare-func": "1.3.2",
                 "q": "1.5.1"
-            },
-            "dependencies": {
-                "q": {
-                    "version": "1.5.1",
-                    "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-                    "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-                    "dev": true
-                }
             }
         },
         "conventional-changelog-writer": {
@@ -4300,8 +4236,8 @@
                 "dateformat": "3.0.3",
                 "handlebars": "4.0.11",
                 "json-stringify-safe": "5.0.1",
-                "lodash": "4.17.5",
-                "meow": "4.0.0",
+                "lodash": "4.17.10",
+                "meow": "4.0.1",
                 "semver": "5.5.0",
                 "split": "1.0.1",
                 "through2": "2.0.3"
@@ -4355,9 +4291,9 @@
                     "dev": true
                 },
                 "meow": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-                    "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
                         "camelcase-keys": "4.2.0",
@@ -4471,8 +4407,8 @@
             "requires": {
                 "JSONStream": "1.3.2",
                 "is-text-path": "1.0.1",
-                "lodash": "4.17.5",
-                "meow": "4.0.0",
+                "lodash": "4.17.10",
+                "meow": "4.0.1",
                 "split2": "2.2.0",
                 "through2": "2.0.3",
                 "trim-off-newlines": "1.0.1"
@@ -4520,9 +4456,9 @@
                     "dev": true
                 },
                 "meow": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
-                    "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
                         "camelcase-keys": "4.2.0",
@@ -4693,9 +4629,9 @@
             "dev": true
         },
         "create-ecdh": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
-            "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
                 "bn.js": "4.11.8",
@@ -4711,7 +4647,7 @@
                 "cipher-base": "1.0.4",
                 "inherits": "2.0.3",
                 "md5.js": "1.3.4",
-                "ripemd160": "2.0.1",
+                "ripemd160": "2.0.2",
                 "sha.js": "2.4.11"
             }
         },
@@ -4724,8 +4660,8 @@
                 "cipher-base": "1.0.4",
                 "create-hash": "1.2.0",
                 "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
                 "sha.js": "2.4.11"
             }
         },
@@ -4735,21 +4671,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "shebang-command": "1.2.0",
                 "which": "1.3.0"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-                    "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
-                    }
-                }
             }
         },
         "cryptiles": {
@@ -4780,12 +4704,12 @@
             "requires": {
                 "browserify-cipher": "1.0.1",
                 "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.1",
+                "create-ecdh": "4.0.3",
                 "create-hash": "1.2.0",
                 "create-hmac": "1.1.7",
                 "diffie-hellman": "5.0.3",
                 "inherits": "2.0.3",
-                "pbkdf2": "3.0.14",
+                "pbkdf2": "3.0.16",
                 "public-encrypt": "4.0.2",
                 "randombytes": "2.0.6",
                 "randomfill": "1.0.4"
@@ -4921,7 +4845,7 @@
                     "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
                     "dev": true,
                     "requires": {
-                        "regenerate": "1.3.3",
+                        "regenerate": "1.4.0",
                         "regjsgen": "0.2.0",
                         "regjsparser": "0.1.5"
                     }
@@ -4940,7 +4864,7 @@
             "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
             "dev": true,
             "requires": {
-                "mdn-data": "1.1.1",
+                "mdn-data": "1.1.2",
                 "source-map": "0.5.7"
             }
         },
@@ -5009,7 +4933,7 @@
                     "dev": true,
                     "requires": {
                         "browserslist": "1.7.7",
-                        "caniuse-db": "1.0.30000827",
+                        "caniuse-db": "1.0.30000840",
                         "normalize-range": "0.1.2",
                         "num2fraction": "1.2.2",
                         "postcss": "5.2.18",
@@ -5022,8 +4946,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000827",
-                        "electron-to-chromium": "1.3.42"
+                        "caniuse-db": "1.0.30000840",
+                        "electron-to-chromium": "1.3.45"
                     }
                 },
                 "postcss": {
@@ -5138,6 +5062,15 @@
                 "word-wrap": "1.2.3"
             }
         },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "dev": true,
+            "requires": {
+                "es5-ext": "0.10.42"
+            }
+        },
         "d3": {
             "version": "3.5.17",
             "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
@@ -5157,9 +5090,9 @@
             "dev": true
         },
         "d3-color": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
-            "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.0.tgz",
+            "integrity": "sha512-dmL9Zr/v39aSSMnLOTd58in2RbregCg4UtGyUArvEKTTN6S3HKEy+ziBWVYo9PTzRyVW+pUBHUtRKz0HYX+SQg==",
             "dev": true
         },
         "d3-dispatch": {
@@ -5181,12 +5114,12 @@
             }
         },
         "d3-interpolate": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
-            "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.2.0.tgz",
+            "integrity": "sha512-zLvTk8CREPFfc/2XglPQriAsXkzoRDAyBzndtKJWrZmHw7kmOWHNS11e40kPTd/oGk8P5mFJW5uBbcFQ+ybxyA==",
             "dev": true,
             "requires": {
-                "d3-color": "1.0.3"
+                "d3-color": "1.2.0"
             }
         },
         "d3-quadtree": {
@@ -5310,9 +5243,9 @@
             "dev": true
         },
         "deep-extend": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-            "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+            "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
             "dev": true
         },
         "deep-is": {
@@ -5600,15 +5533,7 @@
             "dev": true,
             "requires": {
                 "ip": "1.1.5",
-                "safe-buffer": "5.1.1"
-            },
-            "dependencies": {
-                "ip": {
-                    "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-                    "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-                    "dev": true
-                }
+                "safe-buffer": "5.1.2"
             }
         },
         "dns-txt": {
@@ -5785,9 +5710,9 @@
             "dev": true
         },
         "duplexify": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-            "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+            "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
                 "end-of-stream": "1.4.1",
@@ -5834,15 +5759,15 @@
             "dev": true
         },
         "ejs": {
-            "version": "2.5.8",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.8.tgz",
-            "integrity": "sha512-QIDZL54fyV8MDcAsO91BMH1ft2qGGaHIJsJIA/+t+7uvXol1dm413fPcUgUb4k8F/9457rx4/KFE4XfDifrQxQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+            "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.42",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.42.tgz",
-            "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
+            "version": "1.3.45",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
+            "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g=",
             "dev": true
         },
         "elegant-spinner": {
@@ -5896,7 +5821,7 @@
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "dev": true,
             "requires": {
-                "iconv-lite": "0.4.19"
+                "iconv-lite": "0.4.23"
             }
         },
         "end-of-stream": {
@@ -5952,7 +5877,7 @@
                 "arraybuffer.slice": "0.0.7",
                 "base64-arraybuffer": "0.1.5",
                 "blob": "0.0.4",
-                "has-binary2": "1.0.2"
+                "has-binary2": "1.0.3"
             }
         },
         "enhanced-resolve": {
@@ -5987,9 +5912,9 @@
             "dev": true
         },
         "env-ci": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-1.6.0.tgz",
-            "integrity": "sha512-DK9wJ1s498dBW4fn8kPcGzD5QpQSCtm3tw8UgjNdhiGTvQ3PR7/WeCXHx4pltGPi2x8Wlk5s5/BNshM7aDK8XA==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-1.7.2.tgz",
+            "integrity": "sha512-FyxH6t3kg8l2ha507BQYgTA3G7p4Xntx+TwjkNuBf96mKD1p/tTpaU3jJinCBzXUJb9zb+X/EyvaOiOHs2JVGA==",
             "dev": true,
             "requires": {
                 "execa": "0.10.0",
@@ -6054,6 +5979,28 @@
                 "is-symbol": "1.0.1"
             }
         },
+        "es5-ext": {
+            "version": "0.10.42",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+            "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+            "dev": true,
+            "requires": {
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "next-tick": "1.0.0"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.42",
+                "es6-symbol": "3.1.1"
+            }
+        },
         "es6-object-assign": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
@@ -6080,6 +6027,16 @@
                     "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
                     "dev": true
                 }
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "dev": true,
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.42"
             }
         },
         "es6-templates": {
@@ -6134,7 +6091,7 @@
             "requires": {
                 "ajv": "5.5.2",
                 "babel-code-frame": "6.26.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "concat-stream": "1.6.2",
                 "cross-spawn": "5.1.0",
                 "debug": "3.1.0",
@@ -6147,15 +6104,15 @@
                 "file-entry-cache": "2.0.0",
                 "functional-red-black-tree": "1.0.1",
                 "glob": "7.1.2",
-                "globals": "11.4.0",
-                "ignore": "3.3.7",
+                "globals": "11.5.0",
+                "ignore": "3.3.8",
                 "imurmurhash": "0.1.4",
                 "inquirer": "3.3.0",
                 "is-resolvable": "1.1.0",
                 "js-yaml": "3.11.0",
                 "json-stable-stringify-without-jsonify": "1.0.1",
                 "levn": "0.3.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "minimatch": "3.0.4",
                 "mkdirp": "0.5.1",
                 "natural-compare": "1.4.0",
@@ -6194,14 +6151,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cli-cursor": {
@@ -6232,7 +6189,7 @@
                     "dev": true,
                     "requires": {
                         "chardet": "0.4.2",
-                        "iconv-lite": "0.4.19",
+                        "iconv-lite": "0.4.23",
                         "tmp": "0.0.33"
                     }
                 },
@@ -6246,9 +6203,9 @@
                     }
                 },
                 "globals": {
-                    "version": "11.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
-                    "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+                    "version": "11.5.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
+                    "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
                     "dev": true
                 },
                 "has-flag": {
@@ -6264,12 +6221,12 @@
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "3.1.0",
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.1",
                         "cli-cursor": "2.1.0",
                         "cli-width": "2.2.0",
                         "external-editor": "2.2.0",
                         "figures": "2.0.0",
-                        "lodash": "4.17.5",
+                        "lodash": "4.17.10",
                         "mute-stream": "0.0.7",
                         "run-async": "2.3.0",
                         "rx-lite": "4.0.8",
@@ -6316,7 +6273,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -6347,7 +6304,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "strip-ansi": {
@@ -6360,9 +6317,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -6412,7 +6369,7 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "resolve": "1.7.0"
+                "resolve": "1.7.1"
             },
             "dependencies": {
                 "debug": {
@@ -6441,7 +6398,7 @@
                 "is-absolute": "0.2.6",
                 "lodash.get": "4.4.2",
                 "node-libs-browser": "2.1.0",
-                "resolve": "1.7.0",
+                "resolve": "1.7.1",
                 "semver": "5.5.0"
             },
             "dependencies": {
@@ -6550,7 +6507,7 @@
                 "eslint-import-resolver-node": "0.3.2",
                 "eslint-module-utils": "2.2.0",
                 "has": "1.0.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "minimatch": "3.0.4",
                 "read-pkg-up": "2.0.0"
             },
@@ -6708,9 +6665,9 @@
             "dev": true
         },
         "espurify": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.7.0.tgz",
-            "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.0.tgz",
+            "integrity": "sha512-jdkJG9jswjKCCDmEridNUuIQei9algr+o66ZZ19610ZoBsiWLRsQGNYS4HGez3Z/DsR0lhANGAqiwBUclPuNag==",
             "dev": true,
             "requires": {
                 "core-js": "2.3.0"
@@ -6753,9 +6710,9 @@
             "dev": true
         },
         "eventemitter3": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-            "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+            "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
             "dev": true
         },
         "events": {
@@ -6780,7 +6737,7 @@
             "dev": true,
             "requires": {
                 "md5.js": "1.3.4",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "execa": {
@@ -6919,18 +6876,18 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "2.2.4"
             },
             "dependencies": {
                 "fill-range": {
-                    "version": "2.2.3",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                    "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
                         "is-number": "2.1.0",
                         "isobject": "2.1.0",
-                        "randomatic": "1.1.7",
+                        "randomatic": "3.0.0",
                         "repeat-element": "1.1.2",
                         "repeat-string": "1.6.1"
                     }
@@ -7046,6 +7003,24 @@
                 "vary": "1.1.2"
             },
             "dependencies": {
+                "body-parser": {
+                    "version": "1.18.2",
+                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+                    "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.0.0",
+                        "content-type": "1.0.4",
+                        "debug": "2.6.9",
+                        "depd": "1.1.2",
+                        "http-errors": "1.6.3",
+                        "iconv-lite": "0.4.19",
+                        "on-finished": "2.3.0",
+                        "qs": "6.5.1",
+                        "raw-body": "2.3.2",
+                        "type-is": "1.6.16"
+                    }
+                },
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7069,6 +7044,62 @@
                         "statuses": "1.4.0",
                         "unpipe": "1.0.0"
                     }
+                },
+                "iconv-lite": {
+                    "version": "0.4.19",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+                    "dev": true
+                },
+                "raw-body": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+                    "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+                    "dev": true,
+                    "requires": {
+                        "bytes": "3.0.0",
+                        "http-errors": "1.6.2",
+                        "iconv-lite": "0.4.19",
+                        "unpipe": "1.0.0"
+                    },
+                    "dependencies": {
+                        "depd": {
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+                            "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+                            "dev": true
+                        },
+                        "http-errors": {
+                            "version": "1.6.2",
+                            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+                            "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+                            "dev": true,
+                            "requires": {
+                                "depd": "1.1.1",
+                                "inherits": "2.0.3",
+                                "setprototypeof": "1.0.3",
+                                "statuses": "1.4.0"
+                            }
+                        },
+                        "setprototypeof": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+                            "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+                            "dev": true
+                        }
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+                    "dev": true
                 },
                 "statuses": {
                     "version": "1.4.0",
@@ -7243,15 +7274,15 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.0.tgz",
-            "integrity": "sha512-4F75PTznkNtSKs2pbhtBwRkw8sRwa7LfXx5XaQJOe4IQ6yTjceLDTwM5gj1s80R2t/5WeDC1gVfm3jLE+l39Tw==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.1.tgz",
+            "integrity": "sha512-wSyW1TBK3ia5V+te0rGPXudeMHoUQW6O5Y9oATiaGhpENmEifPDlOdhpsnlj5HoG6ttIvGiY1DdCmI9X2xGMhg==",
             "dev": true,
             "requires": {
                 "@mrmlnc/readdir-enhanced": "2.2.1",
                 "glob-parent": "3.1.0",
                 "is-glob": "4.0.0",
-                "merge2": "1.2.1",
+                "merge2": "1.2.2",
                 "micromatch": "3.1.10"
             },
             "dependencies": {
@@ -7338,7 +7369,7 @@
                 "object-assign": "4.1.1",
                 "promise": "7.3.1",
                 "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.17"
+                "ua-parser-js": "0.7.18"
             },
             "dependencies": {
                 "core-js": {
@@ -7489,7 +7520,7 @@
             "dev": true,
             "requires": {
                 "commondir": "1.0.1",
-                "make-dir": "1.2.0",
+                "make-dir": "1.3.0",
                 "pkg-dir": "2.0.0"
             }
         },
@@ -7666,20 +7697,18 @@
             "dev": true
         },
         "flatten-vertex-data": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.0.tgz",
-            "integrity": "sha1-1hyU8qZWTzAdZni3JhYWrwAEcIw=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
+            "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
             "dev": true,
             "requires": {
-                "array-pack-2d": "0.1.1",
-                "dtype": "2.0.0",
-                "is-typedarray": "1.0.0"
+                "dtype": "2.0.0"
             }
         },
         "flow-parser": {
-            "version": "0.69.0",
-            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.69.0.tgz",
-            "integrity": "sha1-N4tRKNbQtVSosvFqTKPhq5ZJ8A4=",
+            "version": "0.72.0",
+            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.72.0.tgz",
+            "integrity": "sha512-kFaDtviKlD/rHi6NRp42KTbnPgz/nKcWUJQhqDnLDeKA8uGcRVSy0YlQjaf9M3pFo5PgC3SNFnCPpQGLtHjH2w==",
             "dev": true
         },
         "flush-write-stream": {
@@ -7857,31 +7886,21 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
+            "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
             "dev": true,
             "optional": true,
             "requires": {
                 "nan": "2.10.0",
-                "node-pre-gyp": "0.6.39"
+                "node-pre-gyp": "0.9.1"
             },
             "dependencies": {
                 "abbrev": {
-                    "version": "1.1.0",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
-                },
-                "ajv": {
-                    "version": "4.11.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
@@ -7889,7 +7908,7 @@
                     "dev": true
                 },
                 "aproba": {
-                    "version": "1.1.1",
+                    "version": "1.2.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -7901,91 +7920,25 @@
                     "optional": true,
                     "requires": {
                         "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "readable-stream": "2.3.6"
                     }
-                },
-                "asn1": {
-                    "version": "0.2.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "asynckit": {
-                    "version": "0.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "aws4": {
-                    "version": "1.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "balanced-match": {
-                    "version": "0.4.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "bcrypt-pbkdf": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "tweetnacl": "0.14.5"
-                    }
-                },
-                "block-stream": {
-                    "version": "0.0.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                },
-                "boom": {
-                    "version": "2.10.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "1.1.7",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "buffer-shims": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true
                 },
-                "caseless": {
-                    "version": "0.12.0",
+                "brace-expansion": {
+                    "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
                 },
-                "co": {
-                    "version": "4.6.0",
+                "chownr": {
+                    "version": "1.0.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -7994,14 +7947,6 @@
                     "version": "1.1.0",
                     "bundled": true,
                     "dev": true
-                },
-                "combined-stream": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "delayed-stream": "1.0.0"
-                    }
                 },
                 "concat-map": {
                     "version": "0.0.1",
@@ -8016,35 +7961,11 @@
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
-                },
-                "cryptiles": {
-                    "version": "2.0.5",
-                    "bundled": true,
                     "dev": true,
-                    "requires": {
-                        "boom": "2.10.1"
-                    }
-                },
-                "dashdash": {
-                    "version": "1.14.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
+                    "optional": true
                 },
                 "debug": {
-                    "version": "2.6.8",
+                    "version": "2.6.9",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -8058,11 +7979,6 @@
                     "dev": true,
                     "optional": true
                 },
-                "delayed-stream": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
-                },
                 "delegates": {
                     "version": "1.0.0",
                     "bundled": true,
@@ -8070,74 +7986,25 @@
                     "optional": true
                 },
                 "detect-libc": {
-                    "version": "1.0.2",
+                    "version": "1.0.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
-                "ecc-jsbn": {
-                    "version": "0.1.1",
+                "fs-minipass": {
+                    "version": "1.2.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "extend": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "extsprintf": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "forever-agent": {
-                    "version": "0.6.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "minipass": "2.2.4"
                     }
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
-                },
-                "fstream": {
-                    "version": "1.0.11",
-                    "bundled": true,
                     "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
-                    }
-                },
-                "fstream-ignore": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
-                    }
+                    "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
@@ -8145,7 +8012,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
+                        "aproba": "1.2.0",
                         "console-control-strings": "1.1.0",
                         "has-unicode": "2.0.1",
                         "object-assign": "4.1.1",
@@ -8155,27 +8022,11 @@
                         "wide-align": "1.1.2"
                     }
                 },
-                "getpass": {
-                    "version": "0.1.7",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
                 "glob": {
                     "version": "7.1.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "fs.realpath": "1.0.0",
                         "inflight": "1.0.6",
@@ -8185,64 +8036,35 @@
                         "path-is-absolute": "1.0.1"
                     }
                 },
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "bundled": true,
-                    "dev": true
-                },
-                "har-schema": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "har-validator": {
-                    "version": "4.2.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
-                    }
-                },
                 "has-unicode": {
                     "version": "2.0.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
-                "hawk": {
-                    "version": "3.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
-                    }
-                },
-                "hoek": {
-                    "version": "2.16.3",
-                    "bundled": true,
-                    "dev": true
-                },
-                "http-signature": {
-                    "version": "1.1.1",
+                "iconv-lite": {
+                    "version": "0.4.21",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "safer-buffer": "2.1.2"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "3.0.4"
                     }
                 },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "once": "1.4.0",
                         "wrappy": "1.0.2"
@@ -8254,7 +8076,7 @@
                     "dev": true
                 },
                 "ini": {
-                    "version": "1.3.4",
+                    "version": "1.3.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -8267,110 +8089,42 @@
                         "number-is-nan": "1.0.1"
                     }
                 },
-                "is-typedarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "isarray": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
-                },
-                "isstream": {
-                    "version": "0.1.2",
-                    "bundled": true,
                     "dev": true,
                     "optional": true
-                },
-                "jodid25519": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "json-schema": {
-                    "version": "0.2.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "json-stable-stringify": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "jsonify": "0.0.0"
-                    }
-                },
-                "json-stringify-safe": {
-                    "version": "5.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "jsonify": {
-                    "version": "0.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "jsprim": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "mime-db": {
-                    "version": "1.27.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "mime-types": {
-                    "version": "2.1.15",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "1.27.0"
-                    }
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
                     "dev": true
+                },
+                "minipass": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "2.2.4"
+                    }
                 },
                 "mkdirp": {
                     "version": "0.5.1",
@@ -8386,23 +8140,33 @@
                     "dev": true,
                     "optional": true
                 },
-                "node-pre-gyp": {
-                    "version": "0.6.39",
+                "needle": {
+                    "version": "2.2.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
-                        "hawk": "3.1.3",
+                        "debug": "2.6.9",
+                        "iconv-lite": "0.4.21",
+                        "sax": "1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.9.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.3",
                         "mkdirp": "0.5.1",
+                        "needle": "2.2.0",
                         "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
-                        "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
+                        "npm-packlist": "1.1.10",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.6",
+                        "rimraf": "2.6.2",
+                        "semver": "5.5.0",
+                        "tar": "4.4.1"
                     }
                 },
                 "nopt": {
@@ -8411,12 +8175,28 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.1.10",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
                     }
                 },
                 "npmlog": {
-                    "version": "4.1.0",
+                    "version": "4.1.2",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -8431,12 +8211,6 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "dev": true
-                },
-                "oauth-sign": {
-                    "version": "0.8.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -8465,7 +8239,7 @@
                     "optional": true
                 },
                 "osenv": {
-                    "version": "0.1.4",
+                    "version": "0.1.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -8477,39 +8251,23 @@
                 "path-is-absolute": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
-                },
-                "performance-now": {
-                    "version": "0.2.0",
-                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
-                    "version": "1.0.7",
-                    "bundled": true,
-                    "dev": true
-                },
-                "punycode": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "qs": {
-                    "version": "6.4.0",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "rc": {
-                    "version": "1.2.1",
+                    "version": "1.2.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
+                        "ini": "1.3.5",
                         "minimist": "1.2.0",
                         "strip-json-comments": "2.0.1"
                     },
@@ -8523,64 +8281,48 @@
                     }
                 },
                 "readable-stream": {
-                    "version": "2.2.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "request": {
-                    "version": "2.81.0",
+                    "version": "2.3.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.1",
+                    "version": "2.6.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "glob": "7.1.2"
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.0.1",
+                    "version": "5.1.1",
                     "bundled": true,
                     "dev": true
                 },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
                 "semver": {
-                    "version": "5.3.0",
+                    "version": "5.5.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -8597,39 +8339,6 @@
                     "dev": true,
                     "optional": true
                 },
-                "sntp": {
-                    "version": "1.0.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "sshpk": {
-                    "version": "1.13.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
@@ -8641,18 +8350,13 @@
                     }
                 },
                 "string_decoder": {
-                    "version": "1.0.1",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "5.1.1"
                     }
-                },
-                "stringstream": {
-                    "version": "0.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
@@ -8669,80 +8373,25 @@
                     "optional": true
                 },
                 "tar": {
-                    "version": "2.2.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
-                    }
-                },
-                "tar-pack": {
-                    "version": "3.4.0",
+                    "version": "4.4.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
-                },
-                "tough-cookie": {
-                    "version": "2.3.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "punycode": "1.4.1"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
-                "tweetnacl": {
-                    "version": "0.14.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "uid-number": {
-                    "version": "0.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
-                },
-                "uuid": {
-                    "version": "3.0.1",
-                    "bundled": true,
                     "dev": true,
                     "optional": true
-                },
-                "verror": {
-                    "version": "1.3.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "extsprintf": "1.0.2"
-                    }
                 },
                 "wide-align": {
                     "version": "1.1.2",
@@ -8755,6 +8404,11 @@
                 },
                 "wrappy": {
                     "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.2",
                     "bundled": true,
                     "dev": true
                 }
@@ -9002,7 +8656,7 @@
                         "lowercase-keys": "1.0.1",
                         "p-cancelable": "0.3.0",
                         "p-timeout": "1.2.1",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "timed-out": "4.0.1",
                         "url-parse-lax": "1.0.0",
                         "url-to-options": "1.0.1"
@@ -9055,7 +8709,7 @@
                     "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.5"
+                        "lodash": "4.17.10"
                     }
                 },
                 "commander": {
@@ -9133,7 +8787,7 @@
                 "dup": "1.0.0",
                 "extract-frustum-planes": "1.0.0",
                 "gl-buffer": "2.1.2",
-                "gl-mat4": "1.1.4",
+                "gl-mat4": "1.2.0",
                 "gl-shader": "4.2.0",
                 "gl-state": "1.0.0",
                 "gl-vao": "1.3.0",
@@ -9294,16 +8948,15 @@
             "dev": true
         },
         "gl-mat4": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.1.4.tgz",
-            "integrity": "sha1-HolbVYkuVqiWhnq9g30483oXgIY=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
+            "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA==",
             "dev": true
         },
         "gl-matrix": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.3.1.tgz",
-            "integrity": "sha1-LyqzQnwqeAHC/GtCL+SYZgxYwEA=",
-            "dev": true
+            "integrity": "sha1-LyqzQnwqeAHC/GtCL+SYZgxYwEA="
         },
         "gl-matrix-invert": {
             "version": "1.0.0",
@@ -9313,7 +8966,7 @@
             "requires": {
                 "gl-mat2": "1.0.1",
                 "gl-mat3": "1.0.0",
-                "gl-mat4": "1.1.4"
+                "gl-mat4": "1.2.0"
             }
         },
         "gl-mesh3d": {
@@ -9325,7 +8978,7 @@
                 "barycentric": "1.0.1",
                 "colormap": "2.3.0",
                 "gl-buffer": "2.1.2",
-                "gl-mat4": "1.1.4",
+                "gl-mat4": "1.2.0",
                 "gl-shader": "4.2.1",
                 "gl-texture2d": "2.1.0",
                 "gl-vao": "1.3.0",
@@ -9393,7 +9046,7 @@
                 "a-big-triangle": "1.0.3",
                 "gl-axes3d": "1.2.7",
                 "gl-fbo": "2.0.5",
-                "gl-mat4": "1.1.4",
+                "gl-mat4": "1.2.0",
                 "gl-select-static": "2.0.2",
                 "gl-shader": "4.2.1",
                 "gl-spikes3d": "1.0.6",
@@ -9446,7 +9099,7 @@
             "dev": true,
             "requires": {
                 "gl-mat3": "1.0.0",
-                "gl-vec3": "1.1.1",
+                "gl-vec3": "1.1.3",
                 "gl-vec4": "1.0.1"
             }
         },
@@ -9457,7 +9110,7 @@
             "dev": true,
             "requires": {
                 "gl-buffer": "2.1.2",
-                "gl-mat4": "1.1.4",
+                "gl-mat4": "1.2.0",
                 "gl-shader": "4.2.0",
                 "gl-vao": "1.3.0",
                 "glslify": "6.1.1",
@@ -9537,7 +9190,7 @@
                 "colormap": "2.3.0",
                 "dup": "1.0.0",
                 "gl-buffer": "2.1.2",
-                "gl-mat4": "1.1.4",
+                "gl-mat4": "1.2.0",
                 "gl-shader": "4.2.0",
                 "gl-texture2d": "2.1.0",
                 "gl-vao": "1.3.0",
@@ -9570,9 +9223,9 @@
             "dev": true
         },
         "gl-vec3": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/gl-vec3/-/gl-vec3-1.1.1.tgz",
-            "integrity": "sha512-hCJ3nIv589YrKVBvoG/NvKXtbGrAwsjGkZ9k/sQwBj6kuFaxNftHzdfPhe60kFVK6Z8du1HXp33W/6ZPL2R91Q==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/gl-vec3/-/gl-vec3-1.1.3.tgz",
+            "integrity": "sha512-jduKUqT0SGH02l8Yl+mV1yVsDfYgQAJyXGxkJQGyxPLHRiW25DwVIRPt6uvhrEMHftJfqhqKthRcyZqNEl9Xdw==",
             "dev": true
         },
         "gl-vec4": {
@@ -9903,7 +9556,7 @@
             "requires": {
                 "bl": "1.1.2",
                 "concat-stream": "1.5.2",
-                "duplexify": "3.5.4",
+                "duplexify": "3.6.0",
                 "falafel": "2.1.0",
                 "from2": "2.3.0",
                 "glsl-resolve": "0.0.1",
@@ -9911,7 +9564,7 @@
                 "glslify-bundle": "5.0.0",
                 "glslify-deps": "1.3.0",
                 "minimist": "1.2.0",
-                "resolve": "1.7.0",
+                "resolve": "1.7.1",
                 "stack-trace": "0.0.9",
                 "static-eval": "2.0.0",
                 "tape": "4.8.0",
@@ -9950,13 +9603,13 @@
                 "graceful-fs": "4.1.11",
                 "inherits": "2.0.3",
                 "map-limit": "0.0.1",
-                "resolve": "1.7.0"
+                "resolve": "1.7.1"
             }
         },
         "got": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-8.3.0.tgz",
-            "integrity": "sha512-kBNy/S2CGwrYgDSec5KTWGKUvupwkkTVAjIsVFF2shXO13xpZdFP4d4kxa//CLX2tN/rV0aYwK8vY6UKWGn2vQ==",
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
+            "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
             "dev": true,
             "requires": {
                 "@sindresorhus/is": "0.7.0",
@@ -9972,7 +9625,7 @@
                 "p-cancelable": "0.4.1",
                 "p-timeout": "2.0.1",
                 "pify": "3.0.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "timed-out": "4.0.1",
                 "url-parse-lax": "3.0.0",
                 "url-to-options": "1.0.1"
@@ -10010,7 +9663,7 @@
             "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "gzip-size": {
@@ -10113,9 +9766,9 @@
             }
         },
         "has-binary2": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.2.tgz",
-            "integrity": "sha1-6D26SfC5vk0CbSc2U1DZ8D9Uvpg=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+            "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
             "dev": true,
             "requires": {
                 "isarray": "2.0.1"
@@ -10169,6 +9822,12 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
             "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
             "dev": true
         },
         "has-to-string-tag-x": {
@@ -10225,7 +9884,7 @@
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "hash.js": {
@@ -10263,7 +9922,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "request": "2.85.0"
             }
         },
@@ -10362,7 +10021,7 @@
             "requires": {
                 "es6-templates": "0.2.3",
                 "fastparse": "1.1.1",
-                "html-minifier": "3.5.14",
+                "html-minifier": "3.5.15",
                 "loader-utils": "1.1.0",
                 "object-assign": "4.1.1"
             },
@@ -10381,9 +10040,9 @@
             }
         },
         "html-minifier": {
-            "version": "3.5.14",
-            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.14.tgz",
-            "integrity": "sha512-sZjw6zhQgyUnIlIPU+W80XpRjWjdxHtNcxjfyOskOsCTDKytcfLY04wsQY/83Yqb4ndoiD2FtauiL7Yg6uUQFQ==",
+            "version": "3.5.15",
+            "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.15.tgz",
+            "integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
             "dev": true,
             "requires": {
                 "camel-case": "3.0.0",
@@ -10392,7 +10051,7 @@
                 "he": "1.1.1",
                 "param-case": "2.1.1",
                 "relateurl": "0.2.7",
-                "uglify-js": "3.3.20"
+                "uglify-js": "3.3.25"
             },
             "dependencies": {
                 "commander": {
@@ -10408,9 +10067,9 @@
                     "dev": true
                 },
                 "uglify-js": {
-                    "version": "3.3.20",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.20.tgz",
-                    "integrity": "sha512-WpLkWCf9sGvGZnIvBV0PNID9BATQNT/IXKAmqegfKzIPcTmTV3FP8NQpoogQkt/Y402x2sOFdaHUmqFY9IZp+g==",
+                    "version": "3.3.25",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.25.tgz",
+                    "integrity": "sha512-hobogryjDV36VrLK3Y69ou4REyrTApzUblVFmdQOYRe8cYaSmFJXMb4dR9McdvYDSbeNdzUgYr2YVukJaErJcA==",
                     "dev": true,
                     "requires": {
                         "commander": "2.15.1",
@@ -10425,12 +10084,12 @@
             "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
             "dev": true,
             "requires": {
-                "html-minifier": "3.5.14",
+                "html-minifier": "3.5.15",
                 "loader-utils": "0.2.17",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "pretty-error": "2.1.1",
                 "tapable": "1.0.0",
-                "toposort": "1.0.6",
+                "toposort": "1.0.7",
                 "util.promisify": "1.0.0"
             },
             "dependencies": {
@@ -10514,41 +10173,30 @@
             }
         },
         "http-parser-js": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
-            "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
+            "version": "0.4.12",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
+            "integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08=",
             "dev": true
         },
         "http-proxy": {
-            "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-            "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+            "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.2.0",
+                "eventemitter3": "3.1.0",
+                "follow-redirects": "1.4.1",
                 "requires-port": "1.0.0"
             }
         },
         "http-proxy-agent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
-            "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
             "dev": true,
             "requires": {
-                "agent-base": "2.1.1",
-                "debug": "2.6.9",
-                "extend": "3.0.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
             }
         },
         "http-proxy-middleware": {
@@ -10557,9 +10205,9 @@
             "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
             "dev": true,
             "requires": {
-                "http-proxy": "1.16.2",
+                "http-proxy": "1.17.0",
                 "is-glob": "4.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "micromatch": "3.1.10"
             },
             "dependencies": {
@@ -10614,32 +10262,23 @@
             "dev": true
         },
         "https-proxy-agent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-            "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+            "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
             "dev": true,
             "requires": {
-                "agent-base": "2.1.1",
-                "debug": "2.6.9",
-                "extend": "3.0.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
+                "agent-base": "4.2.0",
+                "debug": "3.1.0"
             }
         },
         "iconv-lite": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-            "dev": true
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "2.1.2"
+            }
         },
         "icss-replace-symbols": {
             "version": "1.1.0",
@@ -10653,7 +10292,7 @@
             "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             }
         },
         "ieee754": {
@@ -10669,9 +10308,9 @@
             "dev": true
         },
         "ignore": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-            "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+            "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
             "dev": true
         },
         "image-size": {
@@ -10756,9 +10395,9 @@
             "dev": true
         },
         "inflection": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
-            "integrity": "sha1-W//LEZetPoEFD44X4hZoCH7p6y8=",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+            "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
             "dev": true,
             "optional": true
         },
@@ -10793,7 +10432,7 @@
                 "is-plain-obj": "1.1.0",
                 "object-assign": "4.1.1",
                 "svgo": "0.7.2",
-                "uglify-js": "3.3.20"
+                "uglify-js": "3.3.25"
             },
             "dependencies": {
                 "commander": {
@@ -10812,9 +10451,9 @@
                     }
                 },
                 "domhandler": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-                    "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+                    "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
                     "dev": true,
                     "requires": {
                         "domelementtype": "1.3.0"
@@ -10827,7 +10466,7 @@
                     "dev": true,
                     "requires": {
                         "domelementtype": "1.3.0",
-                        "domhandler": "2.4.1",
+                        "domhandler": "2.4.2",
                         "domutils": "1.5.1",
                         "entities": "1.1.1",
                         "inherits": "2.0.3",
@@ -10841,9 +10480,9 @@
                     "dev": true
                 },
                 "uglify-js": {
-                    "version": "3.3.20",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.20.tgz",
-                    "integrity": "sha512-WpLkWCf9sGvGZnIvBV0PNID9BATQNT/IXKAmqegfKzIPcTmTV3FP8NQpoogQkt/Y402x2sOFdaHUmqFY9IZp+g==",
+                    "version": "3.3.25",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.25.tgz",
+                    "integrity": "sha512-hobogryjDV36VrLK3Y69ou4REyrTApzUblVFmdQOYRe8cYaSmFJXMb4dR9McdvYDSbeNdzUgYr2YVukJaErJcA==",
                     "dev": true,
                     "requires": {
                         "commander": "2.15.1",
@@ -10924,7 +10563,7 @@
                 "cli-width": "2.2.0",
                 "external-editor": "1.1.1",
                 "figures": "1.7.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "mute-stream": "0.0.6",
                 "pinkie-promise": "2.0.1",
                 "run-async": "2.3.0",
@@ -10979,7 +10618,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -10990,7 +10629,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -11056,11 +10695,10 @@
             "dev": true
         },
         "ip": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz",
-            "integrity": "sha1-x+NWzeoiWucbNtcPLnGpK6TkJZA=",
-            "dev": true,
-            "optional": true
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
         },
         "ipaddr.js": {
             "version": "1.6.0",
@@ -11597,12 +11235,12 @@
             "dev": true
         },
         "issue-parser": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-1.0.3.tgz",
-            "integrity": "sha512-jJeDfplV9Y3ZQIKodmu1aB8X8oNusb8PCL6iK9Z0umJWnmvvu1NJZ2aWitJlEmYOdJOLhcKcFirDX6z/nECNvQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-2.0.0.tgz",
+            "integrity": "sha512-+dBeNWTdqfC4GX+xJMFmLuzYxY/ve9tUxU1V1INcdq+7c2bbTEojrk14vli1JcGzI0tFCXrF8Ys3hX8J+1NVjw==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "4.17.10"
             }
         },
         "istanbul": {
@@ -11799,10 +11437,10 @@
                 "babel-preset-es2015": "6.24.1",
                 "babel-preset-stage-1": "6.24.1",
                 "babel-register": "6.26.0",
-                "babylon": "7.0.0-beta.44",
-                "colors": "1.2.1",
-                "flow-parser": "0.69.0",
-                "lodash": "4.17.5",
+                "babylon": "7.0.0-beta.46",
+                "colors": "1.2.5",
+                "flow-parser": "0.72.0",
+                "lodash": "4.17.10",
                 "micromatch": "2.3.11",
                 "neo-async": "2.5.1",
                 "node-dir": "0.1.8",
@@ -11828,9 +11466,9 @@
                     "dev": true
                 },
                 "babylon": {
-                    "version": "7.0.0-beta.44",
-                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-                    "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+                    "version": "7.0.0-beta.46",
+                    "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.46.tgz",
+                    "integrity": "sha512-WFJlg2WatdkXRFMpk7BN/Uzzkjkcjk+WaqnrSCpay+RYl4ypW9ZetZyT9kNt22IH/BQNst3M6PaaBn9IXsUNrg==",
                     "dev": true
                 },
                 "braces": {
@@ -12059,10 +11697,10 @@
             "dev": true,
             "requires": {
                 "bluebird": "3.5.1",
-                "body-parser": "1.18.2",
+                "body-parser": "1.18.3",
                 "browserify": "14.5.0",
                 "chokidar": "1.7.0",
-                "colors": "1.2.1",
+                "colors": "1.2.5",
                 "combine-lists": "1.0.1",
                 "connect": "3.6.6",
                 "core-js": "2.3.0",
@@ -12071,17 +11709,17 @@
                 "expand-braces": "0.1.2",
                 "glob": "7.1.2",
                 "graceful-fs": "4.1.11",
-                "http-proxy": "1.16.2",
+                "http-proxy": "1.17.0",
                 "isbinaryfile": "3.0.2",
-                "lodash": "4.17.5",
-                "log4js": "2.5.3",
+                "lodash": "4.17.10",
+                "log4js": "2.6.0",
                 "mime": "1.6.0",
                 "minimatch": "3.0.4",
                 "optimist": "0.6.1",
                 "qjobs": "1.2.0",
                 "range-parser": "1.2.0",
                 "rimraf": "2.6.2",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "socket.io": "2.0.4",
                 "source-map": "0.6.1",
                 "tmp": "0.0.33",
@@ -12297,15 +11935,6 @@
                 "worker-loader": "1.1.1"
             },
             "dependencies": {
-                "async": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-                    "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "4.17.5"
-                    }
-                },
                 "commander": {
                     "version": "2.11.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
@@ -12478,7 +12107,7 @@
                 "log-update": "1.0.2",
                 "ora": "0.2.3",
                 "p-map": "1.2.0",
-                "rxjs": "5.5.9",
+                "rxjs": "5.5.10",
                 "stream-to-observable": "0.2.0",
                 "strip-ansi": "3.0.1"
             },
@@ -12638,9 +12267,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.5",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+            "version": "4.17.10",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
             "dev": true
         },
         "lodash._baseisequal": {
@@ -12753,7 +12382,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2"
+                "chalk": "2.4.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12766,14 +12395,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -12783,9 +12412,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -12804,19 +12433,19 @@
             }
         },
         "log4js": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.5.3.tgz",
-            "integrity": "sha512-YL/qpTxYtK0iWWbuKCrevDZz5lh+OjyHHD+mICqpjnYGKdNRBvPeh/1uYjkKUemT1CSO4wwLOwphWMpKAnD9kw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-2.6.0.tgz",
+            "integrity": "sha512-9rG2W9o0D4GJDzQjno1rRpe+hzK0IEG/uGdjzNROStW/DWhV3sNX2r8OdPKppThlK7gr+08C5FSReWqmaRb/Ww==",
             "dev": true,
             "requires": {
                 "amqplib": "0.5.2",
                 "axios": "0.15.3",
-                "circular-json": "0.5.1",
+                "circular-json": "0.5.4",
                 "date-format": "1.2.0",
                 "debug": "3.1.0",
                 "hipchat-notifier": "1.1.0",
                 "loggly": "1.1.1",
-                "mailgun-js": "0.7.15",
+                "mailgun-js": "0.18.0",
                 "nodemailer": "2.7.2",
                 "redis": "2.8.0",
                 "semver": "5.5.0",
@@ -13036,10 +12665,14 @@
             "dev": true
         },
         "loglevelnext": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.4.tgz",
-            "integrity": "sha512-V3N6LAJAiGwa/zjtvmgs2tyeiCJ23bGNhxXN8R+v7k6TNlSlTz40mIyZYdmO762eBnEFymn0Mhha+WuAhnwMBg==",
-            "dev": true
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
+            "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
+            "dev": true,
+            "requires": {
+                "es6-symbol": "3.1.1",
+                "object.assign": "4.1.0"
+            }
         },
         "longest": {
             "version": "1.0.1",
@@ -13079,11 +12712,14 @@
             "dev": true
         },
         "lru-cache": {
-            "version": "2.6.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz",
-            "integrity": "sha1-5W1jVBSO3o13B7WNFDIg/QjfD9U=",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+            "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
-            "optional": true
+            "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+            }
         },
         "macaddress": {
             "version": "0.2.8",
@@ -13098,6 +12734,14 @@
             "dev": true,
             "requires": {
                 "vlq": "0.2.3"
+            },
+            "dependencies": {
+                "vlq": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+                    "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+                    "dev": true
+                }
             }
         },
         "mailcomposer": {
@@ -13112,58 +12756,27 @@
             }
         },
         "mailgun-js": {
-            "version": "0.7.15",
-            "resolved": "https://registry.npmjs.org/mailgun-js/-/mailgun-js-0.7.15.tgz",
-            "integrity": "sha1-7jZqINrGTDwVwD1sGz4O15UlKrs=",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/mailgun-js/-/mailgun-js-0.18.0.tgz",
+            "integrity": "sha512-o0P6jjZlx5CQj12tvVgDTbgjTqVN0+5h6/6P1+3c6xmozVKBwniQ6Qt3MkCSF0+ueVTbobAfWyGpWRZMJu8t1g==",
             "dev": true,
             "optional": true,
             "requires": {
-                "async": "2.1.5",
-                "debug": "2.2.0",
-                "form-data": "2.1.4",
-                "inflection": "1.10.0",
+                "async": "2.6.0",
+                "debug": "3.1.0",
+                "form-data": "2.3.2",
+                "inflection": "1.12.0",
                 "is-stream": "1.1.0",
                 "path-proxy": "1.0.0",
-                "proxy-agent": "2.0.0",
-                "q": "1.4.1",
+                "promisify-call": "2.0.4",
+                "proxy-agent": "3.0.0",
                 "tsscmp": "1.0.5"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "0.7.1"
-                    }
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.6",
-                        "mime-types": "2.1.18"
-                    }
-                },
-                "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "make-dir": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-            "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+            "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
                 "pify": "3.0.0"
@@ -13243,7 +12856,7 @@
                 "resolve-url": "0.2.1",
                 "shelf-pack": "1.1.0",
                 "supercluster": "2.3.0",
-                "unassertify": "2.1.0",
+                "unassertify": "2.1.1",
                 "unitbezier": "0.0.0",
                 "vector-tile": "1.3.0",
                 "vt-pbf": "2.1.4",
@@ -13324,8 +12937,8 @@
             "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
             "dev": true,
             "requires": {
-                "gl-mat4": "1.1.4",
-                "gl-vec3": "1.1.1"
+                "gl-mat4": "1.2.0",
+                "gl-vec3": "1.1.3"
             }
         },
         "mat4-interpolate": {
@@ -13334,8 +12947,8 @@
             "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
             "dev": true,
             "requires": {
-                "gl-mat4": "1.1.4",
-                "gl-vec3": "1.1.1",
+                "gl-mat4": "1.2.0",
+                "gl-vec3": "1.1.3",
                 "mat4-decompose": "1.0.4",
                 "mat4-recompose": "1.0.4",
                 "quat-slerp": "1.0.1"
@@ -13347,7 +12960,7 @@
             "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
             "dev": true,
             "requires": {
-                "gl-mat4": "1.1.4"
+                "gl-mat4": "1.2.0"
             }
         },
         "math-expression-evaluator": {
@@ -13362,6 +12975,12 @@
             "integrity": "sha1-+4lBvl9evol55xjmJzsXjlhpRWU=",
             "dev": true
         },
+        "math-random": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+            "dev": true
+        },
         "matrix-camera-controller": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.3.tgz",
@@ -13369,8 +12988,8 @@
             "dev": true,
             "requires": {
                 "binary-search-bounds": "1.0.0",
-                "gl-mat4": "1.1.4",
-                "gl-vec3": "1.1.1",
+                "gl-mat4": "1.2.0",
+                "gl-vec3": "1.1.3",
                 "mat4-interpolate": "1.0.4"
             }
         },
@@ -13385,9 +13004,9 @@
             }
         },
         "mdn-data": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.1.tgz",
-            "integrity": "sha512-2J5JENcb4yD5AzBI4ilTakiq2P9gHSsi4LOygnMu/bkchgTiA63AjsHAhDc+3U36AJHRfcz30Qv6Tb7i/Qsiew==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.2.tgz",
+            "integrity": "sha512-HUqqf4U+XdKomJXe2Chw+b1zPXFRUZ3bfUbrGLQ2TGwMOBRULuTHI9geusGqRL4WzsusnLLxYAxV4f/F/8wV+g==",
             "dev": true
         },
         "media-typer": {
@@ -13417,16 +13036,17 @@
             }
         },
         "mem-fs-editor": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-3.0.2.tgz",
-            "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.2.tgz",
+            "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
             "dev": true,
             "requires": {
                 "commondir": "1.0.1",
-                "deep-extend": "0.4.2",
-                "ejs": "2.5.8",
+                "deep-extend": "0.5.1",
+                "ejs": "2.6.1",
                 "glob": "7.1.2",
-                "globby": "6.1.0",
+                "globby": "8.0.1",
+                "isbinaryfile": "3.0.2",
                 "mkdirp": "0.5.1",
                 "multimatch": "2.1.0",
                 "rimraf": "2.6.2",
@@ -13435,15 +13055,36 @@
             },
             "dependencies": {
                 "clone": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
                     "dev": true
                 },
                 "clone-stats": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "globby": {
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+                    "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "1.0.2",
+                        "dir-glob": "2.0.0",
+                        "fast-glob": "2.2.1",
+                        "glob": "7.1.2",
+                        "ignore": "3.3.8",
+                        "pify": "3.0.0",
+                        "slash": "1.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 },
                 "replace-ext": {
@@ -13458,7 +13099,7 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
+                        "clone": "2.1.1",
                         "clone-buffer": "1.0.0",
                         "clone-stats": "1.0.0",
                         "cloneable-readable": "1.1.2",
@@ -13527,9 +13168,9 @@
             }
         },
         "merge2": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.1.tgz",
-            "integrity": "sha512-wUqcG5pxrAcaFI1lkqkMnk3Q7nUxV/NWfpAFSeWUwG9TRODnBDCUHa75mi3o3vLWQ5N4CQERWCauSlP0I3ZqUg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+            "integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg==",
             "dev": true
         },
         "methods": {
@@ -13619,7 +13260,7 @@
             "requires": {
                 "concat-stream": "1.6.2",
                 "convert-source-map": "1.5.1",
-                "duplexify": "3.5.4",
+                "duplexify": "3.6.0",
                 "from2-string": "1.1.0",
                 "uglify-es": "3.3.9",
                 "xtend": "4.0.1"
@@ -13659,7 +13300,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -13676,7 +13317,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "uglify-es": {
@@ -13734,13 +13375,13 @@
             "dev": true,
             "requires": {
                 "concat-stream": "1.5.2",
-                "duplexify": "3.5.4",
+                "duplexify": "3.6.0",
                 "end-of-stream": "1.4.1",
                 "flush-write-stream": "1.0.3",
                 "from2": "2.3.0",
                 "parallel-transform": "1.1.0",
                 "pump": "2.0.1",
-                "pumpify": "1.4.0",
+                "pumpify": "1.5.0",
                 "stream-each": "1.2.2",
                 "through2": "2.0.3"
             }
@@ -13811,7 +13452,7 @@
                 "inherits": "2.0.3",
                 "parents": "1.0.1",
                 "readable-stream": "2.0.6",
-                "resolve": "1.7.0",
+                "resolve": "1.7.1",
                 "stream-combiner2": "1.1.1",
                 "subarg": "1.0.0",
                 "through2": "2.0.3",
@@ -14141,6 +13782,12 @@
             "dev": true,
             "optional": true
         },
+        "next-tick": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+            "dev": true
+        },
         "nextafter": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
@@ -14191,9 +13838,9 @@
             }
         },
         "node-forge": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-            "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+            "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
             "dev": true
         },
         "node-libs-browser": {
@@ -14218,9 +13865,9 @@
                 "querystring-es3": "0.2.1",
                 "readable-stream": "2.3.6",
                 "stream-browserify": "2.0.1",
-                "stream-http": "2.8.1",
+                "stream-http": "2.8.2",
                 "string_decoder": "1.1.1",
-                "timers-browserify": "2.0.6",
+                "timers-browserify": "2.0.10",
                 "tty-browserify": "0.0.0",
                 "url": "0.11.0",
                 "util": "0.10.3",
@@ -14254,7 +13901,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -14265,13 +13912,13 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "timers-browserify": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
-                    "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+                    "version": "2.0.10",
+                    "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+                    "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
                     "dev": true,
                     "requires": {
                         "setimmediate": "1.0.5"
@@ -14296,7 +13943,7 @@
                 "mkdirp": "0.5.1",
                 "nopt": "4.0.1",
                 "npmlog": "4.1.2",
-                "rc": "1.2.6",
+                "rc": "1.2.7",
                 "request": "2.81.0",
                 "rimraf": "2.6.2",
                 "semver": "5.5.0",
@@ -14454,7 +14101,7 @@
                         "oauth-sign": "0.8.2",
                         "performance-now": "0.2.0",
                         "qs": "6.4.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "stringstream": "0.0.5",
                         "tough-cookie": "2.3.4",
                         "tunnel-agent": "0.6.0",
@@ -14488,13 +14135,6 @@
                 "socks": "1.1.9"
             },
             "dependencies": {
-                "ip": {
-                    "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-                    "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-                    "dev": true,
-                    "optional": true
-                },
                 "socks": {
                     "version": "1.1.9",
                     "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
@@ -14801,6 +14441,18 @@
                 "isobject": "3.0.1"
             }
         },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "1.1.2",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.0.11"
+            }
+        },
         "object.getownpropertydescriptors": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -14943,7 +14595,7 @@
             "dev": true,
             "requires": {
                 "filtered-vector": "1.2.4",
-                "gl-mat4": "1.1.4"
+                "gl-mat4": "1.2.0"
             }
         },
         "original": {
@@ -15083,12 +14735,12 @@
             "dev": true
         },
         "p-retry": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-1.0.0.tgz",
-            "integrity": "sha1-OSczKkt9cCabU1UVEX/FR9oaaWg=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-2.0.0.tgz",
+            "integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
             "dev": true,
             "requires": {
-                "retry": "0.10.1"
+                "retry": "0.12.0"
             }
         },
         "p-timeout": {
@@ -15107,56 +14759,34 @@
             "dev": true
         },
         "pac-proxy-agent": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-1.1.0.tgz",
-            "integrity": "sha512-QBELCWyLYPgE2Gj+4wUEiMscHrQ8nRPBzYItQNOHWavwBt25ohZHQC4qnd5IszdVVrFbLsQ+dPkm6eqdjJAmwQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-2.0.2.tgz",
+            "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
             "dev": true,
             "optional": true,
             "requires": {
-                "agent-base": "2.1.1",
-                "debug": "2.6.9",
-                "extend": "3.0.1",
+                "agent-base": "4.2.0",
+                "debug": "3.1.0",
                 "get-uri": "2.0.1",
-                "http-proxy-agent": "1.0.0",
-                "https-proxy-agent": "1.0.0",
-                "pac-resolver": "2.0.0",
-                "raw-body": "2.3.2",
-                "socks-proxy-agent": "2.1.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "pac-resolver": "3.0.0",
+                "raw-body": "2.3.3",
+                "socks-proxy-agent": "3.0.1"
             }
         },
         "pac-resolver": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-2.0.0.tgz",
-            "integrity": "sha1-mbiNLxk/ve78HJpSnB8yYKtSd80=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
+            "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
             "dev": true,
             "optional": true,
             "requires": {
-                "co": "3.0.6",
+                "co": "4.6.0",
                 "degenerator": "1.0.4",
-                "ip": "1.0.1",
+                "ip": "1.1.5",
                 "netmask": "1.0.6",
                 "thunkify": "2.1.2"
-            },
-            "dependencies": {
-                "co": {
-                    "version": "3.0.6",
-                    "resolved": "https://registry.npmjs.org/co/-/co-3.0.6.tgz",
-                    "integrity": "sha1-FEXyJsXrlWE45oyawwFn6n0ua9o=",
-                    "dev": true,
-                    "optional": true
-                }
             }
         },
         "pad": {
@@ -15215,7 +14845,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -15226,7 +14856,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -15259,7 +14889,7 @@
                 "browserify-aes": "1.2.0",
                 "create-hash": "1.2.0",
                 "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.14"
+                "pbkdf2": "3.0.16"
             }
         },
         "parse-css-font": {
@@ -15361,7 +14991,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "9.6.4"
+                "@types/node": "10.0.9"
             }
         },
         "parseqs": {
@@ -15487,15 +15117,15 @@
             }
         },
         "pbkdf2": {
-            "version": "3.0.14",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+            "version": "3.0.16",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+            "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "dev": true,
             "requires": {
                 "create-hash": "1.2.0",
                 "create-hmac": "1.1.7",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
                 "sha.js": "2.4.11"
             }
         },
@@ -15594,7 +15224,7 @@
                 "3d-view": "2.0.0",
                 "@plotly/d3-sankey": "0.5.0",
                 "alpha-shape": "1.0.0",
-                "bubleify": "1.1.0",
+                "bubleify": "1.2.0",
                 "canvas-fit": "1.5.0",
                 "color-normalize": "1.0.3",
                 "color-rgba": "2.0.0",
@@ -15610,7 +15240,7 @@
                 "gl-error3d": "1.0.7",
                 "gl-heatmap2d": "1.0.4",
                 "gl-line3d": "1.1.2",
-                "gl-mat4": "1.1.4",
+                "gl-mat4": "1.2.0",
                 "gl-mesh3d": "1.3.2",
                 "gl-plot2d": "1.3.1",
                 "gl-plot3d": "1.5.5",
@@ -15634,7 +15264,7 @@
                 "ndarray-ops": "1.2.2",
                 "polybooljs": "1.2.0",
                 "regl": "1.3.1",
-                "regl-error2d": "2.0.4",
+                "regl-error2d": "2.0.5",
                 "regl-line2d": "2.1.6",
                 "regl-scatter2d": "2.3.0",
                 "right-now": "1.0.0",
@@ -15668,18 +15298,18 @@
             "dev": true
         },
         "point-cluster": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.2.tgz",
-            "integrity": "sha512-LmjEyihXXjGSgPkrjM29MMmNroNB6PIGCCeMQPcINHEZyI4tiTPaC1BGrCHNJfeDgvsh1X3qKaxwcZZ92Apz1w==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.4.tgz",
+            "integrity": "sha512-jVjzC1vYoZlvcLWi170i41he5LhJTncOgFPaZx1uoqNn+8q+24xjLS9yG68XfN6/U1F52kliD6a3oXjJduerTQ==",
             "dev": true,
             "requires": {
                 "array-bounds": "1.0.1",
                 "array-normalize": "1.1.3",
                 "binary-search-bounds": "2.0.4",
-                "bubleify": "1.1.0",
+                "bubleify": "1.2.0",
                 "clamp": "1.0.1",
                 "dtype": "2.0.0",
-                "flatten-vertex-data": "1.0.0",
+                "flatten-vertex-data": "1.0.2",
                 "is-obj": "1.0.1",
                 "math-log2": "1.0.1",
                 "parse-rect": "1.2.0"
@@ -15761,14 +15391,14 @@
             "dev": true
         },
         "postcss": {
-            "version": "6.0.21",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.21.tgz",
-            "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
+            "version": "6.0.22",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
+            "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "source-map": "0.6.1",
-                "supports-color": "5.3.0"
+                "supports-color": "5.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -15781,14 +15411,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -15804,9 +15434,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -16148,7 +15778,7 @@
             "dev": true,
             "requires": {
                 "loader-utils": "1.1.0",
-                "postcss": "6.0.21",
+                "postcss": "6.0.22",
                 "postcss-load-config": "1.2.0",
                 "schema-utils": "0.4.5"
             },
@@ -16242,7 +15872,7 @@
                 "caniuse-api": "1.6.1",
                 "postcss": "5.2.18",
                 "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.1"
+                "vendors": "1.0.2"
             },
             "dependencies": {
                 "browserslist": {
@@ -16251,8 +15881,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000827",
-                        "electron-to-chromium": "1.3.42"
+                        "caniuse-db": "1.0.30000840",
+                        "electron-to-chromium": "1.3.45"
                     }
                 },
                 "postcss": {
@@ -16427,7 +16057,7 @@
             "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             }
         },
         "postcss-modules-local-by-default": {
@@ -16437,7 +16067,7 @@
             "dev": true,
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             }
         },
         "postcss-modules-scope": {
@@ -16447,7 +16077,7 @@
             "dev": true,
             "requires": {
                 "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             }
         },
         "postcss-modules-values": {
@@ -16457,7 +16087,7 @@
             "dev": true,
             "requires": {
                 "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.21"
+                "postcss": "6.0.22"
             }
         },
         "postcss-normalize-charset": {
@@ -16818,7 +16448,7 @@
             "dev": true,
             "requires": {
                 "posthtml-parser": "0.2.1",
-                "posthtml-render": "1.1.3"
+                "posthtml-render": "1.1.4"
             }
         },
         "posthtml-parser": {
@@ -16832,9 +16462,9 @@
             },
             "dependencies": {
                 "domhandler": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
-                    "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+                    "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
                     "dev": true,
                     "requires": {
                         "domelementtype": "1.3.0"
@@ -16847,7 +16477,7 @@
                     "dev": true,
                     "requires": {
                         "domelementtype": "1.3.0",
-                        "domhandler": "2.4.1",
+                        "domhandler": "2.4.2",
                         "domutils": "1.5.1",
                         "entities": "1.1.1",
                         "inherits": "2.0.3",
@@ -16866,18 +16496,18 @@
             }
         },
         "posthtml-rename-id": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/posthtml-rename-id/-/posthtml-rename-id-1.0.3.tgz",
-            "integrity": "sha512-zaaHJSTihw1fsx2L81npO6gmDYu4yZuHfRX89IsJDhcRIV1P8SKJY5m1xDRZQh542flidwNS+70/pVAK8yMYOA==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/posthtml-rename-id/-/posthtml-rename-id-1.0.7.tgz",
+            "integrity": "sha512-SHKfb7xVEgB1FUl5BI20fjV2kFfQTLrQn/ORjl6LceKqm5cTE853iO6014TtQMvvpiwv1ZtyXH4sbn1Qoceg5A==",
             "dev": true,
             "requires": {
                 "escape-string-regexp": "1.0.5"
             }
         },
         "posthtml-render": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.1.3.tgz",
-            "integrity": "sha512-aYvEMUxvKAv7D+ob2qlosyEL5qzsxCvauN/gjkRxr7fsW3+R2CJ1L3YHxx9kAjBJehmSwbNkSKzREdVfz1NWew==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.1.4.tgz",
+            "integrity": "sha512-jL6eFIzoN3xUEvbo33OAkSDE2VIKU4JQ1wENOows1DpfnrdapR/K3Q1/fB43Mq7wQlcSgRm23nFrvoioufM7eA==",
             "dev": true
         },
         "posthtml-svg-mode": {
@@ -16889,7 +16519,7 @@
                 "merge-options": "0.0.64",
                 "posthtml": "0.9.2",
                 "posthtml-parser": "0.2.1",
-                "posthtml-render": "1.1.3"
+                "posthtml-render": "1.1.4"
             }
         },
         "prelude-ls": {
@@ -16981,6 +16611,16 @@
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
             "dev": true
         },
+        "promisify-call": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/promisify-call/-/promisify-call-2.0.4.tgz",
+            "integrity": "sha1-1IwtRWUszM1SgB3ey9UzptS9X7o=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "with-callback": "1.0.2"
+            }
+        },
         "prop-types": {
             "version": "15.6.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
@@ -17015,33 +16655,28 @@
             }
         },
         "proxy-agent": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.0.0.tgz",
-            "integrity": "sha1-V+tTR6qAXXTsaByyVknbo5yTNJk=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.0.0.tgz",
+            "integrity": "sha512-g6n6vnk8fRf705ShN+FEXFG/SDJaW++lSs0d9KaJh4uBWW/wi7en4Cpo5VYQW3SZzAE121lhB/KLQrbURoubZw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "agent-base": "2.1.1",
-                "debug": "2.6.9",
-                "extend": "3.0.1",
-                "http-proxy-agent": "1.0.0",
-                "https-proxy-agent": "1.0.0",
-                "lru-cache": "2.6.5",
-                "pac-proxy-agent": "1.1.0",
-                "socks-proxy-agent": "2.1.1"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
+                "agent-base": "4.2.0",
+                "debug": "3.1.0",
+                "http-proxy-agent": "2.1.0",
+                "https-proxy-agent": "2.2.1",
+                "lru-cache": "4.1.3",
+                "pac-proxy-agent": "2.0.2",
+                "proxy-from-env": "1.0.0",
+                "socks-proxy-agent": "3.0.1"
             }
+        },
+        "proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+            "dev": true,
+            "optional": true
         },
         "prr": {
             "version": "1.0.1",
@@ -17079,12 +16714,12 @@
             }
         },
         "pumpify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
-            "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
+            "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
+                "duplexify": "3.6.0",
                 "inherits": "2.0.3",
                 "pump": "2.0.1"
             }
@@ -17096,9 +16731,9 @@
             "dev": true
         },
         "q": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-            "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
             "dev": true
         },
         "qjobs": {
@@ -17108,9 +16743,9 @@
             "dev": true
         },
         "qs": {
-            "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-            "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
         "quat-slerp": {
@@ -17224,23 +16859,21 @@
             }
         },
         "randomatic": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+            "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
-                "kind-of": {
+                "is-number": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
                 }
             }
         },
@@ -17250,7 +16883,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "randomfill": {
@@ -17260,7 +16893,7 @@
             "dev": true,
             "requires": {
                 "randombytes": "2.0.6",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "range-parser": {
@@ -17279,41 +16912,15 @@
             }
         },
         "raw-body": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-            "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "http-errors": "1.6.2",
-                "iconv-lite": "0.4.19",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
                 "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "depd": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-                    "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-                    "dev": true
-                },
-                "http-errors": {
-                    "version": "1.6.2",
-                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-                    "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-                    "dev": true,
-                    "requires": {
-                        "depd": "1.1.1",
-                        "inherits": "2.0.3",
-                        "setprototypeof": "1.0.3",
-                        "statuses": "1.5.0"
-                    }
-                },
-                "setprototypeof": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-                    "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-                    "dev": true
-                }
             }
         },
         "raw-loader": {
@@ -17323,12 +16930,12 @@
             "dev": true
         },
         "rc": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-            "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+            "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
             "dev": true,
             "requires": {
-                "deep-extend": "0.4.2",
+                "deep-extend": "0.5.1",
                 "ini": "1.3.5",
                 "minimist": "1.2.0",
                 "strip-json-comments": "2.0.1"
@@ -17371,7 +16978,7 @@
             "dev": true,
             "requires": {
                 "pify": "3.0.0",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             },
             "dependencies": {
                 "pify": {
@@ -17483,7 +17090,7 @@
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "requires": {
-                "resolve": "1.7.0"
+                "resolve": "1.7.1"
             }
         },
         "redent": {
@@ -17587,9 +17194,9 @@
             }
         },
         "regenerate": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-            "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+            "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
             "dev": true
         },
         "regenerator-runtime": {
@@ -17662,7 +17269,7 @@
             "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
             "dev": true,
             "requires": {
-                "regenerate": "1.3.3",
+                "regenerate": "1.4.0",
                 "regjsgen": "0.2.0",
                 "regjsparser": "0.1.5"
             }
@@ -17673,8 +17280,8 @@
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "dev": true,
             "requires": {
-                "rc": "1.2.6",
-                "safe-buffer": "5.1.1"
+                "rc": "1.2.7",
+                "safe-buffer": "5.1.2"
             }
         },
         "regjsgen": {
@@ -17707,15 +17314,15 @@
             "dev": true
         },
         "regl-error2d": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.4.tgz",
-            "integrity": "sha512-EsK+KJ2OREwMyVQ5jRBcoHN3vWPM8RSKU6mHlAVZ4sh71XsbQh4ob+IQ200nHasvusWY6ensMZG+RwTbG5tvXQ==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.5.tgz",
+            "integrity": "sha512-hBxGSY0F9S3+JsobYiQBKdZ+0oWNpM6k8zeRxVDyv5rbZ2HNclVInrT82em+JPZ+GEh0OLmZdlS4BbPIuYAk2w==",
             "dev": true,
             "requires": {
                 "array-bounds": "1.0.1",
-                "bubleify": "1.1.0",
+                "bubleify": "1.2.0",
                 "color-normalize": "1.0.3",
-                "flatten-vertex-data": "1.0.0",
+                "flatten-vertex-data": "1.0.2",
                 "object-assign": "4.1.1",
                 "pick-by-alias": "1.2.0",
                 "to-float32": "1.0.0",
@@ -17730,10 +17337,10 @@
             "requires": {
                 "array-bounds": "1.0.1",
                 "array-normalize": "1.1.3",
-                "bubleify": "1.1.0",
+                "bubleify": "1.2.0",
                 "color-normalize": "1.0.3",
                 "earcut": "2.1.3",
-                "flatten-vertex-data": "1.0.0",
+                "flatten-vertex-data": "1.0.2",
                 "glslify": "6.1.1",
                 "object-assign": "4.1.1",
                 "pick-by-alias": "1.2.0",
@@ -17749,17 +17356,17 @@
             "requires": {
                 "array-range": "1.0.1",
                 "array-rearrange": "2.2.2",
-                "bubleify": "1.1.0",
+                "bubleify": "1.2.0",
                 "clamp": "1.0.1",
                 "color-id": "1.1.0",
                 "color-normalize": "1.0.3",
-                "flatten-vertex-data": "1.0.0",
+                "flatten-vertex-data": "1.0.2",
                 "glslify": "6.1.1",
                 "is-iexplorer": "1.0.0",
                 "object-assign": "4.1.1",
                 "parse-rect": "1.2.0",
                 "pick-by-alias": "1.2.0",
-                "point-cluster": "3.1.2",
+                "point-cluster": "3.1.4",
                 "to-float32": "1.0.0",
                 "update-diff": "1.1.0"
             }
@@ -17846,8 +17453,8 @@
                 "mime-types": "2.1.18",
                 "oauth-sign": "0.8.2",
                 "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
                 "stringstream": "0.0.5",
                 "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.6.0",
@@ -17862,7 +17469,7 @@
             "optional": true,
             "requires": {
                 "extend": "3.0.1",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "request": "2.85.0",
                 "when": "3.7.8"
             }
@@ -17911,9 +17518,9 @@
             }
         },
         "resolve": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
-            "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+            "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "requires": {
                 "path-parse": "1.0.5"
             }
@@ -18001,9 +17608,9 @@
             "dev": true
         },
         "retry": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-            "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
             "dev": true
         },
         "right-align": {
@@ -18037,24 +17644,13 @@
             }
         },
         "ripemd160": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "2.0.2",
+                "hash-base": "3.0.4",
                 "inherits": "2.0.3"
-            },
-            "dependencies": {
-                "hash-base": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-                    "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                }
             }
         },
         "riveter": {
@@ -18222,18 +17818,18 @@
             }
         },
         "rxjs": {
-            "version": "5.5.9",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.9.tgz",
-            "integrity": "sha512-DHG9AHmCmgaFWgjBcXp6NxFDmh3MvIA62GqTWmLnTzr/3oZ6h5hLD8NA+9j+GF0jEwklNIpI4KuuyLG8UWMEvQ==",
+            "version": "5.5.10",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+            "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
             "dev": true,
             "requires": {
                 "symbol-observable": "1.0.1"
             }
         },
         "safe-buffer": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
         "safe-regex": {
@@ -18244,6 +17840,12 @@
             "requires": {
                 "ret": "0.1.15"
             }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "sane-topojson": {
             "version": "2.0.0",
@@ -18263,26 +17865,32 @@
             "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
             "dev": true,
             "requires": {
-                "ajv": "6.4.0",
-                "ajv-keywords": "3.1.0"
+                "ajv": "6.5.0",
+                "ajv-keywords": "3.2.0"
             },
             "dependencies": {
                 "ajv": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-                    "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+                    "version": "6.5.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+                    "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "1.1.0",
+                        "fast-deep-equal": "2.0.1",
                         "fast-json-stable-stringify": "2.0.0",
                         "json-schema-traverse": "0.3.1",
-                        "uri-js": "3.0.2"
+                        "uri-js": "4.2.1"
                     }
                 },
                 "ajv-keywords": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-                    "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+                    "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
                     "dev": true
                 }
             }
@@ -18306,12 +17914,12 @@
             "dev": true
         },
         "selfsigned": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.2.tgz",
-            "integrity": "sha1-tESVgNmZKbZbEKSDiTAaZZIIh1g=",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+            "integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
             "dev": true,
             "requires": {
-                "node-forge": "0.7.1"
+                "node-forge": "0.7.5"
             }
         },
         "semantic-release": {
@@ -18322,21 +17930,21 @@
             "requires": {
                 "@semantic-release/commit-analyzer": "5.0.3",
                 "@semantic-release/error": "2.2.0",
-                "@semantic-release/github": "4.2.11",
-                "@semantic-release/npm": "3.2.4",
-                "@semantic-release/release-notes-generator": "6.0.9",
+                "@semantic-release/github": "4.2.16",
+                "@semantic-release/npm": "3.2.5",
+                "@semantic-release/release-notes-generator": "6.0.10",
                 "aggregate-error": "1.0.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "cosmiconfig": "4.0.0",
                 "debug": "3.1.0",
-                "env-ci": "1.6.0",
+                "env-ci": "1.7.2",
                 "execa": "0.10.0",
                 "get-stream": "3.0.0",
                 "git-log-parser": "1.2.0",
                 "git-url-parse": "8.3.1",
                 "hook-std": "0.4.0",
                 "hosted-git-info": "2.6.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "marked": "0.3.19",
                 "marked-terminal": "2.0.0",
                 "p-locate": "2.0.0",
@@ -18369,20 +17977,20 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cliui": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "2.1.1",
@@ -18538,9 +18146,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -18558,7 +18166,7 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.0.0",
+                        "cliui": "4.1.0",
                         "decamelize": "1.2.0",
                         "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
@@ -18634,9 +18242,9 @@
             }
         },
         "serialize-javascript": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
-            "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+            "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
             "dev": true
         },
         "serve-index": {
@@ -18731,7 +18339,7 @@
             "dev": true,
             "requires": {
                 "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "shader-loader": {
@@ -18911,7 +18519,7 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "ci-job-number": "0.3.0",
                 "compression-webpack-plugin": "1.1.11",
                 "cosmiconfig": "4.0.0",
@@ -18924,7 +18532,7 @@
                 "read-pkg-up": "3.0.0",
                 "style-loader": "0.20.3",
                 "webpack": "4.5.0",
-                "webpack-bundle-analyzer": "2.11.1",
+                "webpack-bundle-analyzer": "2.11.3",
                 "yargs": "11.0.0"
             },
             "dependencies": {
@@ -18950,20 +18558,20 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cliui": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "2.1.1",
@@ -19006,9 +18614,9 @@
                     "requires": {
                         "array-union": "1.0.2",
                         "dir-glob": "2.0.0",
-                        "fast-glob": "2.2.0",
+                        "fast-glob": "2.2.1",
                         "glob": "7.1.2",
-                        "ignore": "3.3.7",
+                        "ignore": "3.3.8",
                         "pify": "3.0.0",
                         "slash": "1.0.0"
                     }
@@ -19126,9 +18734,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -19146,7 +18754,7 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.0.0",
+                        "cliui": "4.1.0",
                         "decamelize": "1.2.0",
                         "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
@@ -19249,7 +18857,7 @@
                 "extend-shallow": "2.0.1",
                 "map-cache": "0.2.2",
                 "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
+                "source-map-resolve": "0.5.2",
                 "use": "3.1.0"
             },
             "dependencies": {
@@ -19432,7 +19040,7 @@
             "requires": {
                 "component-emitter": "1.2.1",
                 "debug": "3.1.0",
-                "has-binary2": "1.0.2",
+                "has-binary2": "1.0.3",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -19465,7 +19073,7 @@
                 "faye-websocket": "0.11.1",
                 "inherits": "2.0.3",
                 "json3": "3.3.2",
-                "url-parse": "1.3.0"
+                "url-parse": "1.4.0"
             },
             "dependencies": {
                 "debug": {
@@ -19496,24 +19104,15 @@
             "requires": {
                 "ip": "1.1.5",
                 "smart-buffer": "1.1.15"
-            },
-            "dependencies": {
-                "ip": {
-                    "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-                    "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-                    "dev": true
-                }
             }
         },
         "socks-proxy-agent": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-2.1.1.tgz",
-            "integrity": "sha512-sFtmYqdUK5dAMh85H0LEVFUCO7OhJJe1/z2x/Z6mxp3s7/QPf1RkZmpZy+BpuU0bEjcV9npqKjq9Y3kwFUjnxw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
+            "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
             "dev": true,
             "requires": {
-                "agent-base": "2.1.1",
-                "extend": "3.0.1",
+                "agent-base": "4.2.0",
                 "socks": "1.1.10"
             }
         },
@@ -19561,12 +19160,12 @@
             "dev": true
         },
         "source-map-resolve": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.0",
+                "atob": "2.1.1",
                 "decode-uri-component": "0.2.0",
                 "resolve-url": "0.2.1",
                 "source-map-url": "0.4.0",
@@ -19645,7 +19244,7 @@
                 "debug": "2.6.9",
                 "handle-thing": "1.2.5",
                 "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "select-hose": "2.0.0",
                 "spdy-transport": "2.1.0"
             },
@@ -19672,7 +19271,7 @@
                 "hpack.js": "2.1.6",
                 "obuf": "1.1.2",
                 "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "wbuf": "1.7.3"
             },
             "dependencies": {
@@ -19701,7 +19300,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -19712,7 +19311,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -19782,7 +19381,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "stack-trace": {
@@ -19862,7 +19461,7 @@
                                 "inherits": "2.0.3",
                                 "isarray": "1.0.0",
                                 "process-nextick-args": "2.0.0",
-                                "safe-buffer": "5.1.1",
+                                "safe-buffer": "5.1.2",
                                 "string_decoder": "1.1.1",
                                 "util-deprecate": "1.0.2"
                             }
@@ -20028,7 +19627,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "through2": {
@@ -20089,9 +19688,9 @@
             }
         },
         "stream-http": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-            "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+            "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
             "dev": true,
             "requires": {
                 "builtin-status-codes": "3.0.0",
@@ -20117,7 +19716,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -20128,7 +19727,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -20186,7 +19785,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -20197,7 +19796,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -20402,7 +20001,7 @@
             "dev": true,
             "requires": {
                 "bluebird": "3.5.1",
-                "clone": "2.1.2",
+                "clone": "2.1.1",
                 "he": "1.1.1",
                 "image-size": "0.5.5",
                 "loader-utils": "1.1.0",
@@ -20410,16 +20009,16 @@
                 "micromatch": "3.1.0",
                 "postcss": "5.2.18",
                 "postcss-prefix-selector": "1.6.0",
-                "posthtml-rename-id": "1.0.3",
+                "posthtml-rename-id": "1.0.7",
                 "posthtml-svg-mode": "1.0.2",
                 "query-string": "4.3.4",
                 "traverse": "0.6.6"
             },
             "dependencies": {
                 "clone": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
                     "dev": true
                 },
                 "define-property": {
@@ -20555,9 +20154,9 @@
             }
         },
         "svg-baker-runtime": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/svg-baker-runtime/-/svg-baker-runtime-1.3.3.tgz",
-            "integrity": "sha512-yDnHhVM+nGxLu+Oj/zG07yUPXmJ7XLmekU2XQqL0jaLUazLjxj61uO8IMyww2roUjdMQo4x+J+KIlAp37qIbZQ==",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/svg-baker-runtime/-/svg-baker-runtime-1.3.5.tgz",
+            "integrity": "sha512-BKxJT/Zz9M+K043zXbZf7CA3c10NKWByxobAukO30VLv71OvmpagjG32Z0UIay6ctMaOUmywOKHuceiSDqwUOA==",
             "dev": true,
             "requires": {
                 "deepmerge": "1.3.2",
@@ -20613,7 +20212,7 @@
                 "escape-string-regexp": "1.0.5",
                 "loader-utils": "1.1.0",
                 "svg-baker": "1.2.17",
-                "svg-baker-runtime": "1.3.3",
+                "svg-baker-runtime": "1.3.5",
                 "url-slug": "2.0.0"
             },
             "dependencies": {
@@ -20692,8 +20291,8 @@
             "requires": {
                 "ajv": "5.5.2",
                 "ajv-keywords": "2.1.1",
-                "chalk": "2.3.2",
-                "lodash": "4.17.5",
+                "chalk": "2.4.1",
+                "lodash": "4.17.10",
                 "slice-ansi": "1.0.0",
                 "string-width": "2.1.1"
             },
@@ -20714,14 +20313,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -20756,9 +20355,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -20928,7 +20527,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -20939,7 +20538,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -21040,7 +20639,7 @@
                         "inherits": "2.0.3",
                         "isarray": "1.0.0",
                         "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.1.2",
                         "string_decoder": "1.1.1",
                         "util-deprecate": "1.0.2"
                     }
@@ -21051,7 +20650,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -21080,7 +20679,7 @@
                 "html-entities": "1.2.1",
                 "indent": "0.0.2",
                 "js-yaml": "3.11.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "marked": "0.3.3",
                 "pad": "1.1.0",
                 "parse5": "3.0.3"
@@ -21239,9 +20838,9 @@
             }
         },
         "toposort": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
-            "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+            "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
             "dev": true
         },
         "tough-cookie": {
@@ -21328,7 +20927,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "turntable-camera-controller": {
@@ -21338,8 +20937,8 @@
             "dev": true,
             "requires": {
                 "filtered-vector": "1.2.4",
-                "gl-mat4": "1.1.4",
-                "gl-vec3": "1.1.1"
+                "gl-mat4": "1.2.0",
+                "gl-vec3": "1.1.3"
             }
         },
         "tweetnacl": {
@@ -21397,9 +20996,9 @@
             }
         },
         "ua-parser-js": {
-            "version": "0.7.17",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-            "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+            "version": "0.7.18",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
+            "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==",
             "dev": true
         },
         "uglify-js": {
@@ -21429,7 +21028,7 @@
                 "cacache": "10.0.4",
                 "find-cache-dir": "1.0.0",
                 "schema-utils": "0.4.5",
-                "serialize-javascript": "1.4.0",
+                "serialize-javascript": "1.5.0",
                 "source-map": "0.6.1",
                 "uglify-es": "3.3.9",
                 "webpack-sources": "1.1.0",
@@ -21481,16 +21080,16 @@
                 "acorn": "4.0.13",
                 "call-matcher": "1.0.1",
                 "deep-equal": "1.0.1",
-                "espurify": "1.7.0",
+                "espurify": "1.8.0",
                 "estraverse": "4.2.0",
                 "esutils": "2.0.2",
                 "object-assign": "4.1.1"
             }
         },
         "unassertify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/unassertify/-/unassertify-2.1.0.tgz",
-            "integrity": "sha512-CB3C3vbOwrZydRuGdU8H421r4/qhM8RLuEOo3G+wEFf7kDP4TR+7oDuj1yOik5pUzXMaJmzxICM7akupP1AlJw==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/unassertify/-/unassertify-2.1.1.tgz",
+            "integrity": "sha512-YIAaIlc6/KC9Oib8cVZLlpDDhK1UTEuaDyx9BwD97xqxDZC0cJOqwFcs/Y6K3m73B5VzHsRTBLXNO0dxS/GkTw==",
             "dev": true,
             "requires": {
                 "acorn": "5.5.3",
@@ -21688,9 +21287,9 @@
             "dev": true
         },
         "upath": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-            "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
+            "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww==",
             "dev": true
         },
         "update-diff": {
@@ -21706,9 +21305,9 @@
             "dev": true
         },
         "uri-js": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-            "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+            "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
             "dev": true,
             "requires": {
                 "punycode": "2.1.0"
@@ -21783,19 +21382,19 @@
             }
         },
         "url-parse": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.3.0.tgz",
-            "integrity": "sha512-zPvPA3T7P6M+0iNsgX+iAcAz4GshKrowtQBHHc/28tVsBc8jK7VRCNX+2GEcoE6zDB6XqXhcyiUWPVZY6C70Cg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+            "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
+                "querystringify": "2.0.0",
                 "requires-port": "1.0.0"
             },
             "dependencies": {
                 "querystringify": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
-                    "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+                    "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
                     "dev": true
                 }
             }
@@ -21853,20 +21452,8 @@
             "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.2",
+                "lru-cache": "4.1.3",
                 "tmp": "0.0.33"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-                    "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
-                    }
-                }
             }
         },
         "util": {
@@ -21973,9 +21560,9 @@
             }
         },
         "vendors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
-            "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
+            "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
             "dev": true
         },
         "verror": {
@@ -22021,9 +21608,9 @@
             }
         },
         "vlq": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-            "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
+            "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==",
             "dev": true
         },
         "vm-browserify": {
@@ -22091,9 +21678,9 @@
             }
         },
         "watchpack": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
-            "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+            "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
                 "chokidar": "2.0.3",
@@ -22120,7 +21707,7 @@
                         "anymatch": "2.0.0",
                         "async-each": "1.0.1",
                         "braces": "2.3.2",
-                        "fsevents": "1.1.3",
+                        "fsevents": "1.2.3",
                         "glob-parent": "3.1.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",
@@ -22128,7 +21715,7 @@
                         "normalize-path": "2.1.1",
                         "path-is-absolute": "1.0.1",
                         "readdirp": "2.1.0",
-                        "upath": "1.0.4"
+                        "upath": "1.0.5"
                     }
                 },
                 "glob-parent": {
@@ -22207,9 +21794,9 @@
             "requires": {
                 "acorn": "5.5.3",
                 "acorn-dynamic-import": "3.0.0",
-                "ajv": "6.4.0",
-                "ajv-keywords": "3.1.0",
-                "chrome-trace-event": "0.1.2",
+                "ajv": "6.5.0",
+                "ajv-keywords": "3.2.0",
+                "chrome-trace-event": "0.1.3",
                 "enhanced-resolve": "4.0.0",
                 "eslint-scope": "3.7.1",
                 "loader-runner": "2.3.0",
@@ -22222,7 +21809,7 @@
                 "schema-utils": "0.4.5",
                 "tapable": "1.0.0",
                 "uglifyjs-webpack-plugin": "1.2.4",
-                "watchpack": "1.5.0",
+                "watchpack": "1.6.0",
                 "webpack-sources": "1.1.0"
             },
             "dependencies": {
@@ -22233,21 +21820,21 @@
                     "dev": true
                 },
                 "ajv": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-                    "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+                    "version": "6.5.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+                    "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "1.1.0",
+                        "fast-deep-equal": "2.0.1",
                         "fast-json-stable-stringify": "2.0.0",
                         "json-schema-traverse": "0.3.1",
-                        "uri-js": "3.0.2"
+                        "uri-js": "4.2.1"
                     }
                 },
                 "ajv-keywords": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-                    "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+                    "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
                     "dev": true
                 },
                 "enhanced-resolve": {
@@ -22260,6 +21847,12 @@
                         "memory-fs": "0.4.1",
                         "tapable": "1.0.0"
                     }
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+                    "dev": true
                 },
                 "loader-utils": {
                     "version": "1.1.0",
@@ -22328,9 +21921,9 @@
                     }
                 },
                 "core-js": {
-                    "version": "2.5.5",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-                    "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+                    "version": "2.5.6",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+                    "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
                     "dev": true
                 },
                 "esprima": {
@@ -22369,9 +21962,9 @@
                         "babel-preset-stage-1": "6.24.1",
                         "babel-register": "6.26.0",
                         "babylon": "6.18.0",
-                        "colors": "1.2.1",
-                        "flow-parser": "0.69.0",
-                        "lodash": "4.17.5",
+                        "colors": "1.2.5",
+                        "flow-parser": "0.72.0",
+                        "lodash": "4.17.10",
                         "micromatch": "2.3.11",
                         "node-dir": "0.1.8",
                         "nomnom": "1.8.1",
@@ -22417,7 +22010,7 @@
                     "dev": true,
                     "requires": {
                         "ast-types": "0.10.1",
-                        "core-js": "2.5.5",
+                        "core-js": "2.5.6",
                         "esprima": "4.0.0",
                         "private": "0.1.8",
                         "source-map": "0.6.1"
@@ -22432,20 +22025,20 @@
             }
         },
         "webpack-bundle-analyzer": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.11.1.tgz",
-            "integrity": "sha512-VKUVkVMc6TWVXmF1OxsBXoiRjYiDRA4XT0KqtbLMDK+891VX7FCuklYwzldND8J2upUcHHnuXYNTP+4mSFi4Kg==",
+            "version": "2.11.3",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.11.3.tgz",
+            "integrity": "sha512-MaHZkX9mNGeJLbVT70bNfftSBBdl3w9Q1ThnrH7SESF47SollWm12MwDgjhf8C16R/Ur56PInrLYf0FJIOg24g==",
             "dev": true,
             "requires": {
                 "acorn": "5.5.3",
                 "bfj-node4": "5.3.1",
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "commander": "2.13.0",
-                "ejs": "2.5.8",
+                "ejs": "2.6.1",
                 "express": "4.16.3",
                 "filesize": "3.6.1",
                 "gzip-size": "4.1.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "mkdirp": "0.5.1",
                 "opener": "1.4.3",
                 "ws": "4.1.0"
@@ -22467,14 +22060,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -22484,9 +22077,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -22499,7 +22092,7 @@
                     "dev": true,
                     "requires": {
                         "async-limiter": "1.0.0",
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -22510,32 +22103,32 @@
             "integrity": "sha512-gRoWaxSi2JWiYsn1QgOTb6ENwIeSvN1YExZ+kJ0STsTZK7bWPElW+BBBv1UnTbvcPC3v7E17mK8hlFX8DOYSGw==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "cross-spawn": "6.0.5",
                 "diff": "3.5.0",
                 "enhanced-resolve": "4.0.0",
                 "envinfo": "4.4.2",
                 "glob-all": "3.1.0",
                 "global-modules": "1.0.0",
-                "got": "8.3.0",
+                "got": "8.3.1",
                 "import-local": "1.0.0",
                 "inquirer": "5.2.0",
                 "interpret": "1.1.0",
                 "jscodeshift": "0.5.0",
                 "listr": "0.13.0",
                 "loader-utils": "1.1.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "log-symbols": "2.2.0",
                 "mkdirp": "0.5.1",
                 "p-each-series": "1.0.0",
                 "p-lazy": "1.0.0",
                 "prettier": "1.11.1",
-                "supports-color": "5.3.0",
+                "supports-color": "5.4.0",
                 "v8-compile-cache": "1.1.2",
                 "webpack-addons": "1.1.5",
                 "yargs": "11.1.0",
-                "yeoman-environment": "2.0.6",
-                "yeoman-generator": "2.0.3"
+                "yeoman-environment": "2.1.1",
+                "yeoman-generator": "2.0.5"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -22566,14 +22159,14 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cli-cursor": {
@@ -22586,9 +22179,9 @@
                     }
                 },
                 "cliui": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "2.1.1",
@@ -22641,7 +22234,7 @@
                             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                             "dev": true,
                             "requires": {
-                                "lru-cache": "4.1.2",
+                                "lru-cache": "4.1.3",
                                 "shebang-command": "1.2.0",
                                 "which": "1.3.0"
                             }
@@ -22664,7 +22257,7 @@
                     "dev": true,
                     "requires": {
                         "chardet": "0.4.2",
-                        "iconv-lite": "0.4.19",
+                        "iconv-lite": "0.4.23",
                         "tmp": "0.0.33"
                     }
                 },
@@ -22714,15 +22307,15 @@
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "3.1.0",
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.1",
                         "cli-cursor": "2.1.0",
                         "cli-width": "2.2.0",
                         "external-editor": "2.2.0",
                         "figures": "2.0.0",
-                        "lodash": "4.17.5",
+                        "lodash": "4.17.10",
                         "mute-stream": "0.0.7",
                         "run-async": "2.3.0",
-                        "rxjs": "5.5.9",
+                        "rxjs": "5.5.10",
                         "string-width": "2.1.1",
                         "strip-ansi": "4.0.0",
                         "through": "2.3.8"
@@ -22743,16 +22336,6 @@
                         "big.js": "3.2.0",
                         "emojis-list": "2.1.0",
                         "json5": "0.5.1"
-                    }
-                },
-                "lru-cache": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-                    "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-                    "dev": true,
-                    "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
                     }
                 },
                 "mute-stream": {
@@ -22821,9 +22404,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -22847,7 +22430,7 @@
                     "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.0.0",
+                        "cliui": "4.1.0",
                         "decamelize": "1.2.0",
                         "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
@@ -22909,13 +22492,13 @@
                 "loglevel": "1.6.1",
                 "opn": "5.3.0",
                 "portfinder": "1.0.13",
-                "selfsigned": "1.10.2",
+                "selfsigned": "1.10.3",
                 "serve-index": "1.9.1",
                 "sockjs": "0.3.19",
                 "sockjs-client": "1.1.4",
                 "spdy": "3.4.7",
                 "strip-ansi": "3.0.1",
-                "supports-color": "5.3.0",
+                "supports-color": "5.4.0",
                 "webpack-dev-middleware": "3.1.2",
                 "webpack-log": "1.2.0",
                 "yargs": "11.0.0"
@@ -22952,7 +22535,7 @@
                         "anymatch": "2.0.0",
                         "async-each": "1.0.1",
                         "braces": "2.3.2",
-                        "fsevents": "1.1.3",
+                        "fsevents": "1.2.3",
                         "glob-parent": "3.1.0",
                         "inherits": "2.0.3",
                         "is-binary-path": "1.0.1",
@@ -22960,13 +22543,13 @@
                         "normalize-path": "2.1.1",
                         "path-is-absolute": "1.0.1",
                         "readdirp": "2.1.0",
-                        "upath": "1.0.4"
+                        "upath": "1.0.5"
                     }
                 },
                 "cliui": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-                    "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
                         "string-width": "2.1.1",
@@ -23041,12 +22624,6 @@
                     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                     "dev": true
                 },
-                "ip": {
-                    "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-                    "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-                    "dev": true
-                },
                 "is-extglob": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -23113,9 +22690,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -23148,7 +22725,7 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.0.0",
+                        "cliui": "4.1.0",
                         "decamelize": "1.2.0",
                         "find-up": "2.1.0",
                         "get-caller-file": "1.0.2",
@@ -23179,9 +22756,9 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "log-symbols": "2.2.0",
-                "loglevelnext": "1.0.4",
+                "loglevelnext": "1.0.5",
                 "uuid": "3.2.1"
             },
             "dependencies": {
@@ -23195,14 +22772,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -23212,9 +22789,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -23246,7 +22823,7 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": "0.4.11",
+                "http-parser-js": "0.4.12",
                 "websocket-extensions": "0.1.3"
             }
         },
@@ -23328,6 +22905,13 @@
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
             "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
             "dev": true
+        },
+        "with-callback": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/with-callback/-/with-callback-1.0.2.tgz",
+            "integrity": "sha1-oJYpuakgAo1yFAT7Q1vc/1yRvCE=",
+            "dev": true,
+            "optional": true
         },
         "word-wrap": {
             "version": "1.2.3",
@@ -23424,7 +23008,7 @@
             "dev": true,
             "requires": {
                 "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.1",
+                "safe-buffer": "5.1.2",
                 "ultron": "1.1.1"
             }
         },
@@ -23510,22 +23094,24 @@
             "dev": true
         },
         "yeoman-environment": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.0.6.tgz",
-            "integrity": "sha512-jzHBTTy8EPI4ImV8dpUMt+Q5zELkSU5xvGpndHcHudQ4tqN6YgIWaCGmRFl+HDchwRUkcgyjQ+n6/w5zlJBCPg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.1.1.tgz",
+            "integrity": "sha512-IBLwCUrJrDxBYuwdYm1wuF3O/CR2LpXR0rFS684QOrU6x69DPPrsdd20dZOFaedZ/M9sON7po73WhO3I1CbgNQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
+                "cross-spawn": "6.0.5",
                 "debug": "3.1.0",
                 "diff": "3.5.0",
                 "escape-string-regexp": "1.0.5",
-                "globby": "6.1.0",
+                "globby": "8.0.1",
                 "grouped-queue": "0.3.3",
-                "inquirer": "3.3.0",
+                "inquirer": "5.2.0",
                 "is-scoped": "1.0.0",
-                "lodash": "4.17.5",
+                "lodash": "4.17.10",
                 "log-symbols": "2.2.0",
                 "mem-fs": "1.1.3",
+                "strip-ansi": "4.0.0",
                 "text-table": "0.2.0",
                 "untildify": "3.0.2"
             },
@@ -23552,14 +23138,14 @@
                     }
                 },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
                     }
                 },
                 "cli-cursor": {
@@ -23571,6 +23157,19 @@
                         "restore-cursor": "2.0.0"
                     }
                 },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "1.0.4",
+                        "path-key": "2.0.1",
+                        "semver": "5.5.0",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
+                    }
+                },
                 "external-editor": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
@@ -23578,7 +23177,7 @@
                     "dev": true,
                     "requires": {
                         "chardet": "0.4.2",
-                        "iconv-lite": "0.4.19",
+                        "iconv-lite": "0.4.23",
                         "tmp": "0.0.33"
                     }
                 },
@@ -23591,6 +23190,21 @@
                         "escape-string-regexp": "1.0.5"
                     }
                 },
+                "globby": {
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+                    "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "1.0.2",
+                        "dir-glob": "2.0.0",
+                        "fast-glob": "2.2.1",
+                        "glob": "7.1.2",
+                        "ignore": "3.3.8",
+                        "pify": "3.0.0",
+                        "slash": "1.0.0"
+                    }
+                },
                 "has-flag": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -23598,22 +23212,21 @@
                     "dev": true
                 },
                 "inquirer": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-                    "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+                    "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
                     "dev": true,
                     "requires": {
                         "ansi-escapes": "3.1.0",
-                        "chalk": "2.3.2",
+                        "chalk": "2.4.1",
                         "cli-cursor": "2.1.0",
                         "cli-width": "2.2.0",
                         "external-editor": "2.2.0",
                         "figures": "2.0.0",
-                        "lodash": "4.17.5",
+                        "lodash": "4.17.10",
                         "mute-stream": "0.0.7",
                         "run-async": "2.3.0",
-                        "rx-lite": "4.0.8",
-                        "rx-lite-aggregates": "4.0.8",
+                        "rxjs": "5.5.10",
                         "string-width": "2.1.1",
                         "strip-ansi": "4.0.0",
                         "through": "2.3.8"
@@ -23639,6 +23252,12 @@
                     "requires": {
                         "mimic-fn": "1.2.0"
                     }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
                 },
                 "restore-cursor": {
                     "version": "2.0.0",
@@ -23670,9 +23289,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"
@@ -23681,15 +23300,15 @@
             }
         },
         "yeoman-generator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.3.tgz",
-            "integrity": "sha512-mODmrZ26a94djmGZZuIiomSGlN4wULdou29ZwcySupb2e9FdvoCl7Ps2FqHFjEHio3kOl/iBeaNqrnx3C3NwWg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-2.0.5.tgz",
+            "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
             "dev": true,
             "requires": {
                 "async": "2.6.0",
-                "chalk": "2.3.2",
+                "chalk": "2.4.1",
                 "cli-table": "0.3.1",
-                "cross-spawn": "5.1.0",
+                "cross-spawn": "6.0.5",
                 "dargs": "5.1.0",
                 "dateformat": "3.0.3",
                 "debug": "3.1.0",
@@ -23698,19 +23317,19 @@
                 "find-up": "2.1.0",
                 "github-username": "4.1.0",
                 "istextorbinary": "2.2.1",
-                "lodash": "4.17.5",
-                "make-dir": "1.2.0",
-                "mem-fs-editor": "3.0.2",
+                "lodash": "4.17.10",
+                "make-dir": "1.3.0",
+                "mem-fs-editor": "4.0.2",
                 "minimist": "1.2.0",
                 "pretty-bytes": "4.0.2",
                 "read-chunk": "2.1.0",
                 "read-pkg-up": "3.0.0",
                 "rimraf": "2.6.2",
                 "run-async": "2.3.0",
-                "shelljs": "0.8.1",
+                "shelljs": "0.8.2",
                 "text-table": "0.2.0",
                 "through2": "2.0.3",
-                "yeoman-environment": "2.0.6"
+                "yeoman-environment": "2.1.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -23722,24 +23341,28 @@
                         "color-convert": "1.9.1"
                     }
                 },
-                "async": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-                    "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "4.17.5"
-                    }
-                },
                 "chalk": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
                         "ansi-styles": "3.2.1",
                         "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "supports-color": "5.4.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "1.0.4",
+                        "path-key": "2.0.1",
+                        "semver": "5.5.0",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.0"
                     }
                 },
                 "dateformat": {
@@ -23813,9 +23436,9 @@
                     }
                 },
                 "shelljs": {
-                    "version": "0.8.1",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
-                    "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+                    "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
                     "dev": true,
                     "requires": {
                         "glob": "7.1.2",
@@ -23830,9 +23453,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-                    "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
                         "has-flag": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "base64-js": "1.2.1",
         "commander": "2.13.0",
+        "gl-matrix": "2.3.1",
         "jszip": "3.1.5",
         "pako": "1.0.6",
         "shelljs": "0.7.8"
@@ -29,7 +30,6 @@
         "react-dom": "16.2.0",
         "d3": "3.5.17",
         "axios": "0.17.1",
-        "gl-matrix": "2.3.1",
         "hammerjs": "2.0.8",
         "font-awesome": "4.7.0",
         "kw-web-suite": "6.0.2",


### PR DESCRIPTION
Plotly depends on gl-mapbox which depends on gl-matrix 2.5.1 which breaks GPUCompositor.  Moving
gl-matrix from devDependencies to dependencies ensures we get a compatible version.