### PR TITLE
fix(loaders): Remove json-loader

### DIFF
--- a/config/webpack.loaders.js
+++ b/config/webpack.loaders.js
@@ -59,10 +59,6 @@ module.exports = [
     loader: 'shader-loader',
   },
   {
-    test: /\.json$/,
-    loader: 'json-loader',
-  },
-  {
     test: /\.html$/,
     loader: 'html-loader',
   },


### PR DESCRIPTION
Since we no longer pick a `kw-web-suite` which brings `json-loader`, we should be able to get rid of
this.