### PR TITLE
chore(docker): Fix how pip is found

### DIFF
--- a/tools/docker/paraviewweb/scripts/server.sh
+++ b/tools/docker/paraviewweb/scripts/server.sh
@@ -4,7 +4,12 @@
 # If we find it, we can pip install those.
 if [ -f "/pvw/requirements.txt" ]
 then
-  pip install -r "/pvw/requirements.txt"
+  if [ -z "${SYSTEM_PYTHON_PIP}" ]; then
+    PIP_CMD=pip
+  else
+    PIP_CMD="${!SYSTEM_PYTHON_PIP}"
+  fi
+  "${PIP_CMD}" install -r "/pvw/requirements.txt"
 fi
 
 # Copy the launcher config into the location where the start script expects


### PR DESCRIPTION
In newer pv base images (v5.7.0-RC2 and later), ParaView could be built against either Python 2 or 3.  This change supports finding pip in either case.