### PR TITLE
fix(VtkRenderer): Connection and deprecated API

### DIFF
--- a/src/NativeUI/Renderers/NativeImageRenderer/index.js
+++ b/src/NativeUI/Renderers/NativeImageRenderer/index.js
@@ -131,6 +131,9 @@ export default class NativeImageRenderer {
   }
 
   destroy() {
+    if (this.container) {
+      this.container.removeChild(this.canvas);
+    }
     while (this.subscriptions.length) {
       this.subscriptions.pop().unsubscribe();
     }


### PR DESCRIPTION
It cannot recover from websocket shutdown and reconnection, since it sets up
the connection state in componentDidMount and cannot not react to prop changes.

It uses componentWillReceiveProps, which has been deprecated. Another problem
is that the componentWillReceiveProps runs on every render (as far as I can
tell). So VtkRender ends up pushing a SetMaxFrameRate message to the server on
render every time.

This change makes a minimal change to fix both issues, by pushing the state
initialization code to componentDidUpdate, and also cleaning the state up more
properly when the connection object changes.