### PR TITLE
fix(VtkRenderer): Update the view after window resize

### DIFF
--- a/src/React/Renderers/VtkRenderer/index.js
+++ b/src/React/Renderers/VtkRenderer/index.js
@@ -68,6 +68,7 @@ export default class VtkRenderer extends React.Component {
         this.mouseListener.updateSize(clientWidth, clientHeight);
         if (this.binaryImageStream.setViewSize) {
           this.binaryImageStream.setViewSize(clientWidth, clientHeight);
+          this.binaryImageStream.stillRender(clientWidth, clientHeight);
         } else {
           this.props.client.session.call('viewport.size.update', [
             // TODO: viewId change after component mounted isn't handled properly.


### PR DESCRIPTION
The BinaryImageStream code path isn't updated, given that it's deprecated.