### PR TITLE
fix(SizeHelper) allow listening to element size changes

### DIFF
--- a/src/Common/Misc/SizeHelper/api.md
+++ b/src/Common/Misc/SizeHelper/api.md
@@ -15,6 +15,12 @@ Return true only if the SizeHelper has started to listen on Window size change.
 
 Register a callback to be aware when the size of the Window is changing with automatic debouncing.
 
+## onSizeChangeForElement(domElement, callback)
+
+Register a callback to be aware when the size of the given element is changing with automatic debouncing.
+It returns a class with single method, "unsubscribe()". The caller must run unsubscribe to stop
+listening to the size-change events.
+
 ## startListening()
 
 Start listening on Window size change.

--- a/src/Common/Misc/SizeHelper/index.js
+++ b/src/Common/Misc/SizeHelper/index.js
@@ -41,8 +41,31 @@ function getSize(domElement, clearCache = false) {
   return cachedSize;
 }
 
+let observer = null;
+
+class Subscriber {
+  constructor(domElement, callback) {
+    observer.observe(domElement);
+    this.fn = observableInstance.on(TOPIC, callback);
+    this.domElement = domElement;
+    this.unsubscribe = this.unsubscribe.bind(this);
+  }
+
+  unsubscribe() {
+    observer.unobserve(this.domElement);
+    this.fn.unsubscribe();
+  }
+}
+
 function onSizeChange(callback) {
   return observableInstance.on(TOPIC, callback);
+}
+
+function onSizeChangeForElement(domElement, callback) {
+  if (!observer) {
+    observer = new ResizeObserver(windowListener);
+  }
+  return new Subscriber(domElement, callback);
 }
 
 function triggerChange() {
@@ -79,6 +102,7 @@ export default {
   getSize,
   isListening,
   onSizeChange,
+  onSizeChangeForElement,
   startListening,
   stopListening,
   triggerChange,

--- a/src/NativeUI/Renderers/NativeImageRenderer/index.js
+++ b/src/NativeUI/Renderers/NativeImageRenderer/index.js
@@ -68,7 +68,7 @@ export default class NativeImageRenderer {
 
     // Add size listener
     this.subscriptions.push(
-      SizeHelper.onSizeChange(() => {
+      SizeHelper.onSizeChangeForElement(this.container, () => {
         if (this.container) {
           this.size = SizeHelper.getSize(this.container);
           this.canvas.setAttribute('width', this.size.clientWidth);

--- a/src/React/Renderers/GeometryRenderer/index.js
+++ b/src/React/Renderers/GeometryRenderer/index.js
@@ -16,15 +16,15 @@ export default class GeometryRenderer extends React.Component {
     this.resetCamera = this.resetCamera.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     // Listen to window resize
-    this.sizeSubscription = sizeHelper.onSizeChange(this.updateDimensions);
+    this.sizeSubscription = sizeHelper.onSizeChangeForElement(
+      this.canvasRenderer.parentNode,
+      this.updateDimensions
+    );
 
     // Make sure we monitor window size if it is not already the case
     sizeHelper.startListening();
-  }
-
-  componentDidMount() {
     if (this.props.geometryBuilder) {
       this.props.geometryBuilder.configureRenderer(this.canvasRenderer);
       this.props.geometryBuilder.render();

--- a/src/React/Renderers/ImageRenderer/index.js
+++ b/src/React/Renderers/ImageRenderer/index.js
@@ -215,12 +215,6 @@ export default class ImageRenderer extends React.Component {
     this.imageToDraw.onload = onImageLoaded;
     this.imageToDraw.firstRender = true;
 
-    // Listen to window resize
-    this.sizeSubscription = sizeHelper.onSizeChange(this.updateDimensions);
-
-    // Make sure we monitor window size if it is not already the case
-    sizeHelper.startListening();
-
     // Listen to keyDown
     document.addEventListener('keydown', this.handleKeyDown);
 
@@ -230,6 +224,15 @@ export default class ImageRenderer extends React.Component {
   }
 
   componentDidMount() {
+    // Listen to window resize
+    this.sizeSubscription = sizeHelper.onSizeChange(
+      this.rootContainer,
+      this.updateDimensions
+    );
+
+    // Make sure we monitor window size if it is not already the case
+    sizeHelper.startListening();
+
     this.updateDimensions();
     if (this.imageToDraw.drawToCanvas) {
       this.imageToDraw.drawToCanvas();

--- a/src/React/Renderers/MultiLayoutRenderer/index.js
+++ b/src/React/Renderers/MultiLayoutRenderer/index.js
@@ -80,15 +80,17 @@ export default class MultiViewRenderer extends React.Component {
         active: false,
       });
     });
-
-    // Listen to window resize
-    this.sizeSubscription = sizeHelper.onSizeChange(this.updateDimensions);
-
-    // Make sure we monitor window size if it is not already the case
-    sizeHelper.startListening();
   }
 
   componentDidMount() {
+    // Listen to window resize
+    this.sizeSubscription = sizeHelper.onSizeChangeForElement(
+      this.canvasRenderer.parentNode,
+      this.updateDimensions
+    );
+
+    // Make sure we monitor window size if it is not already the case
+    sizeHelper.startListening();
     this.updateDimensions();
 
     // Attach mouse listener

--- a/src/React/Renderers/PlotlyRenderer/index.js
+++ b/src/React/Renderers/PlotlyRenderer/index.js
@@ -15,12 +15,6 @@ export default class PlotlyRenderer extends React.Component {
   }
 
   componentWillMount() {
-    // Listen to window resize
-    this.sizeSubscription = sizeHelper.onSizeChange(this.updateDimensions);
-
-    // Make sure we monitor window size if it is not already the case
-    sizeHelper.startListening();
-
     this.dataSubscription = this.props.chartBuilder.onDataReady((data) => {
       const container = this.chartRenderer;
       if (!container) {
@@ -65,6 +59,15 @@ export default class PlotlyRenderer extends React.Component {
   }
 
   componentDidMount() {
+    // Listen to window resize
+    this.sizeSubscription = sizeHelper.onSizeChangeForElement(
+      this.chartRenderer,
+      this.updateDimensions
+    );
+
+    // Make sure we monitor window size if it is not already the case
+    sizeHelper.startListening();
+
     this.updateDimensions();
   }
 

--- a/src/React/Renderers/VtkRenderer/index.js
+++ b/src/React/Renderers/VtkRenderer/index.js
@@ -61,7 +61,7 @@ export default class VtkRenderer extends React.Component {
       });
 
       // Attach size listener
-      this.subscription = sizeHelper.onSizeChange(() => {
+      this.subscription = sizeHelper.onSizeChangeForElement(container, () => {
         /* eslint-disable no-shadow */
         const { clientWidth, clientHeight } = sizeHelper.getSize(container);
         /* eslint-enable no-shadow */

--- a/src/React/Viewers/LineChartViewer/index.js
+++ b/src/React/Viewers/LineChartViewer/index.js
@@ -38,15 +38,18 @@ export default class LineChartViewer extends React.Component {
 
   componentWillMount() {
     this.xPosition = 0;
-    // Listen to window resize
-    this.sizeSubscription = sizeHelper.onSizeChange(this.updateDimensions);
-
-    // Make sure we monitor window size if it is not already the case
-    sizeHelper.startListening();
   }
 
   componentDidMount() {
     this.isReady = true;
+    // Listen to window resize
+    this.sizeSubscription = sizeHelper.onSizeChangeForElement(
+      this.rootContainer.parentNode,
+      this.updateDimensions
+    );
+
+    // Make sure we monitor window size if it is not already the case
+    sizeHelper.startListening();
     this.updateDimensions();
     // this.drawChart();
   }

--- a/src/React/Widgets/EqualizerWidget/index.js
+++ b/src/React/Widgets/EqualizerWidget/index.js
@@ -23,15 +23,15 @@ export default class EqualizerWidget extends React.Component {
     this.clicked = this.clicked.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     // Listen to window resize
-    this.sizeSubscription = SizeHelper.onSizeChange(this.updateDimensions);
+    this.sizeSubscription = SizeHelper.onSizeChangeForElement(
+      this.rootContainer.parentNode,
+      this.updateDimensions
+    );
 
     // Make sure we monitor window size if it is not already the case
     SizeHelper.startListening();
-  }
-
-  componentDidMount() {
     this.updateDimensions();
     this.draw();
     this.mouseHandler = new MouseHandler(this.canvas);

--- a/src/React/Widgets/PieceWiseFunctionEditorWidget/index.js
+++ b/src/React/Widgets/PieceWiseFunctionEditorWidget/index.js
@@ -42,7 +42,10 @@ export default class PieceWiseFunctionEditorWidget extends React.Component {
     this.editor.onEditModeChange(this.props.onEditModeChange);
 
     if (this.props.width === -1 || this.props.height === -1) {
-      this.sizeSubscription = sizeHelper.onSizeChange(this.updateDimensions);
+      this.sizeSubscription = sizeHelper.onSizeChangeForElement(
+        this.rootContainer,
+        this.updateDimensions
+      );
       sizeHelper.startListening();
       this.updateDimensions();
     }

--- a/src/React/Widgets/PieceWiseGaussianFunctionEditorWidget/index.js
+++ b/src/React/Widgets/PieceWiseGaussianFunctionEditorWidget/index.js
@@ -58,7 +58,10 @@ export default class PieceWiseGaussianFunctionEditorWidget extends React.Compone
     }
 
     if (this.props.width === -1 || this.props.height === -1) {
-      this.sizeSubscription = sizeHelper.onSizeChange(this.updateDimensions);
+      this.sizeSubscription = sizeHelper.onSizeChangeForElement(
+        this.rootContainer,
+        this.updateDimensions
+      );
       sizeHelper.startListening();
       this.updateDimensions();
     }


### PR DESCRIPTION
The current SizeHelper reacts only to explicit window size changes and not to
layout changes inside the window. This change adds a new function
onSizeChangeForElement that uses ResizeObserver to detect when the size of a DOM
element a changes.

ResizeObserver is supported by all modern browsers
now (https://caniuse.com/#feat=resizeobserver).

An aside: I'm not sure if element size caching in SizeHelper is adding much
value. If we remove it, the code will become simpler.