### PR TITLE
Fix the mouse wheel <-> distance conversion.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraviewweb",
-  "version": "0.0.0-semantically-release",
+  "version": "0.0.10-semantically-release",
   "description": "Web framework for building interactive visualization relying on VTK or ParaView to produce visualization data",
   "repository": {
     "type": "git",

--- a/src/Common/Misc/SizeHelper/index.js
+++ b/src/Common/Misc/SizeHelper/index.js
@@ -41,16 +41,19 @@ function getSize(domElement, clearCache = false) {
   return cachedSize;
 }
 
+let observer = null;
+
 class Subscriber {
   constructor(domElement, callback) {
     observer.observe(domElement);
     this.fn = observableInstance.on(TOPIC, callback);
     this.domElement = domElement;
+    this.unsubscribe = this.unsubscribe.bind(this);
   }
 
   unsubscribe() {
     observer.unobserve(this.domElement);
-    this.fn();
+    this.fn.unsubscribe();
   }
 }
 

--- a/src/Interaction/Core/MouseHandler/index.js
+++ b/src/Interaction/Core/MouseHandler/index.js
@@ -17,6 +17,11 @@ const eventTypeMapping = {
 };
 const TIMEOUT_BETWEEN_ZOOM = 300;
 
+// If the value is N, one mouse-wheel click is equivalent to dragging the cursor
+// (120 * N) th of the screen. The magic constant 120 corresponds to one wheel
+// click in most browsers.
+const MOUSE_WHEEL_SCALE_FACTOR = 1.0 / (120 * 200);
+
 let handlerCount = 0;
 
 function getModifier(e) {
@@ -168,21 +173,22 @@ export default class MouseHandler {
           event.isFinal = false;
         }
 
+        const clientWidth = this.el.getClientRects()[0].width;
+        const clientHeight = this.el.getClientRects()[0].height;
         if (e.wheelDeltaX === undefined) {
           event.zoom = this.lastScrollZoomFactor;
           this.scrollInternal.deltaY -= e.detail * 2.0;
         } else {
           event.zoom = this.lastScrollZoomFactor;
-          this.scrollInternal.deltaX += e.wheelDeltaX;
-          this.scrollInternal.deltaY += e.wheelDeltaY;
+          this.scrollInternal.deltaX += e.wheelDeltaX * clientWidth * MOUSE_WHEEL_SCALE_FACTOR;
+          this.scrollInternal.deltaY += e.wheelDeltaY * clientHeight * MOUSE_WHEEL_SCALE_FACTOR;
         }
 
         event.deltaX = this.scrollInternal.deltaX;
         event.deltaY = this.scrollInternal.deltaY;
-        event.scale = 1.0 + event.deltaY / this.el.getClientRects()[0].height;
+        event.scale = 1.0 + event.deltaY / clientHeight;
         event.scale = event.scale < 0.1 ? 0.1 : event.scale;
         this.scrollInternal.ts = currentTime;
-
         this.finalZoomEvent = event;
       }
 

--- a/src/React/Renderers/VtkRenderer/index.js
+++ b/src/React/Renderers/VtkRenderer/index.js
@@ -64,6 +64,10 @@ export default class VtkRenderer extends React.Component {
       this.subscription = sizeHelper.onSizeChangeForElement(container, () => {
         /* eslint-disable no-shadow */
         const { clientWidth, clientHeight } = sizeHelper.getSize(container);
+        if (!this.mouseListener) {
+          // already unmounted?
+          return;
+        }
         /* eslint-enable no-shadow */
         this.mouseListener.updateSize(clientWidth, clientHeight);
         if (this.binaryImageStream.setViewSize) {


### PR DESCRIPTION
Before this change, the mouse-wheel click was equivalent to moving the mouse
pointer 120 pixels, where 120 is the hard-code constant for a single mousewheel
click event. There were two problems with this setting:

- The effective zoom scaling factor was dependent on the screen size.
  The smaller the screen, the larger the scaling factor.

- Most of the time, the scaling factor was too coarse.