### PR TITLE
Fix a race between imagestream destruction and subscription.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraviewweb",
-  "version": "0.0.10-semantically-release",
+  "version": "0.0.11-semantically-release",
   "description": "Web framework for building interactive visualization relying on VTK or ParaView to produce visualization data",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraviewweb",
-  "version": "0.0.11-semantically-release",
+  "version": "0.0.11-20210325-2",
   "description": "Web framework for building interactive visualization relying on VTK or ParaView to produce visualization data",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paraviewweb",
-  "version": "0.0.0-semantically-release",
+  "version": "0.0.10-semantically-release",
   "description": "Web framework for building interactive visualization relying on VTK or ParaView to produce visualization data",
   "repository": {
     "type": "git",

--- a/src/Common/Misc/SizeHelper/index.js
+++ b/src/Common/Misc/SizeHelper/index.js
@@ -41,16 +41,19 @@ function getSize(domElement, clearCache = false) {
   return cachedSize;
 }
 
+let observer = null;
+
 class Subscriber {
   constructor(domElement, callback) {
     observer.observe(domElement);
     this.fn = observableInstance.on(TOPIC, callback);
     this.domElement = domElement;
+    this.unsubscribe = this.unsubscribe.bind(this);
   }
 
   unsubscribe() {
     observer.unobserve(this.domElement);
-    this.fn();
+    this.fn.unsubscribe();
   }
 }
 

--- a/src/IO/WebSocket/WslinkImageStream/index.js
+++ b/src/IO/WebSocket/WslinkImageStream/index.js
@@ -56,16 +56,18 @@ function wslinkImageStream(publicAPI, model) {
   };
 
   publicAPI.unsubscribeRenderTopic = () => {
-    model.client.VtkImageDelivery.offRenderChange(
-      model.renderTopicSubscription
-    ).then(
-      (unsubSuccess) => {
-        console.log('Unsubscribe resolved ', unsubSuccess);
-      },
-      (unsubFailure) => {
-        console.log('Unsubscribe error ', unsubFailure);
-      }
-    );
+    if (model.renderTopicSubscription) {
+      model.client.VtkImageDelivery.offRenderChange(
+          model.renderTopicSubscription
+      ).then(
+          (unsubSuccess) => {
+              console.log('Unsubscribe resolved ', unsubSuccess);
+          },
+          (unsubFailure) => {
+              console.log('Unsubscribe error ', unsubFailure);
+          }
+      );
+    }
   };
 
   // subscribeRenderTopic = () => {

--- a/src/Interaction/Core/MouseHandler/index.js
+++ b/src/Interaction/Core/MouseHandler/index.js
@@ -17,6 +17,11 @@ const eventTypeMapping = {
 };
 const TIMEOUT_BETWEEN_ZOOM = 300;
 
+// If the value is N, one mouse-wheel click is equivalent to dragging the cursor
+// (120 * N) th of the screen. The magic constant 120 corresponds to one wheel
+// click in most browsers.
+const MOUSE_WHEEL_SCALE_FACTOR = 1.0 / (120 * 200);
+
 let handlerCount = 0;
 
 function getModifier(e) {
@@ -168,21 +173,22 @@ export default class MouseHandler {
           event.isFinal = false;
         }
 
+        const clientWidth = this.el.getClientRects()[0].width;
+        const clientHeight = this.el.getClientRects()[0].height;
         if (e.wheelDeltaX === undefined) {
           event.zoom = this.lastScrollZoomFactor;
           this.scrollInternal.deltaY -= e.detail * 2.0;
         } else {
           event.zoom = this.lastScrollZoomFactor;
-          this.scrollInternal.deltaX += e.wheelDeltaX;
-          this.scrollInternal.deltaY += e.wheelDeltaY;
+          this.scrollInternal.deltaX += e.wheelDeltaX * clientWidth * MOUSE_WHEEL_SCALE_FACTOR;
+          this.scrollInternal.deltaY += e.wheelDeltaY * clientHeight * MOUSE_WHEEL_SCALE_FACTOR;
         }
 
         event.deltaX = this.scrollInternal.deltaX;
         event.deltaY = this.scrollInternal.deltaY;
-        event.scale = 1.0 + event.deltaY / this.el.getClientRects()[0].height;
+        event.scale = 1.0 + event.deltaY / clientHeight;
         event.scale = event.scale < 0.1 ? 0.1 : event.scale;
         this.scrollInternal.ts = currentTime;
-
         this.finalZoomEvent = event;
       }
 

--- a/src/Interaction/Core/VtkWebMouseListener/index.js
+++ b/src/Interaction/Core/VtkWebMouseListener/index.js
@@ -7,7 +7,7 @@ const modifier = {
   SHIFT: 4,
   CTRL: 8,
 };
-const INTERATION_TOPIC = 'vtk.web.interaction';
+const INTERACTION_TOPIC = 'vtk.web.interaction';
 
 const NoOp = () => {};
 
@@ -48,7 +48,7 @@ export default class VtkMouseListener {
           vtkEvent.action = 'move';
         }
         if (vtkEvent.action !== 'up') {
-          this.emit(INTERATION_TOPIC, true);
+          this.emit(INTERACTION_TOPIC, true);
         }
         if (this.client) {
           const tNow = Date.now();
@@ -89,7 +89,7 @@ export default class VtkMouseListener {
           }
         }
         if (vtkEvent.action === 'up') {
-          this.emit(INTERATION_TOPIC, false);
+          this.emit(INTERACTION_TOPIC, false);
         }
       },
       zoom: (event) => {
@@ -116,7 +116,7 @@ export default class VtkMouseListener {
           vtkEvent.action = 'move';
         }
         if (vtkEvent.action !== 'up') {
-          this.emit(INTERATION_TOPIC, true);
+          this.emit(INTERACTION_TOPIC, true);
         }
         if (this.client) {
           const tNow = Date.now();
@@ -136,7 +136,7 @@ export default class VtkMouseListener {
           }
         }
         if (vtkEvent.action === 'up') {
-          this.emit(INTERATION_TOPIC, false);
+          this.emit(INTERACTION_TOPIC, false);
         }
       },
     };
@@ -164,7 +164,7 @@ export default class VtkMouseListener {
   }
 
   onInteraction(callback) {
-    return this.on(INTERATION_TOPIC, callback);
+    return this.on(INTERACTION_TOPIC, callback);
   }
 
   destroy() {

--- a/src/React/Renderers/VtkRenderer/index.js
+++ b/src/React/Renderers/VtkRenderer/index.js
@@ -64,6 +64,10 @@ export default class VtkRenderer extends React.Component {
       this.subscription = sizeHelper.onSizeChangeForElement(container, () => {
         /* eslint-disable no-shadow */
         const { clientWidth, clientHeight } = sizeHelper.getSize(container);
+        if (!this.mouseListener) {
+          // already unmounted?
+          return;
+        }
         /* eslint-enable no-shadow */
         this.mouseListener.updateSize(clientWidth, clientHeight);
         if (this.binaryImageStream.setViewSize) {

--- a/src/React/Renderers/VtkRenderer/index.js
+++ b/src/React/Renderers/VtkRenderer/index.js
@@ -43,6 +43,9 @@ export default class VtkRenderer extends React.Component {
 
       // Attach interaction listener for image qualitya
       this.mouseListener.onInteraction((interact) => {
+        if (this.props.onInteraction) {
+          this.props.onInteraction(interact);
+        }
         if (this.interacting === interact) {
           return;
         }
@@ -191,6 +194,11 @@ VtkRenderer.propTypes = {
 
   throttleTime: PropTypes.number,
   maxFPS: PropTypes.number,
+
+  // Optional callback that runs on a VtkWebMouseListener.onInteraction event.
+  // Takes a single boolean arg. The arg is true for a mouse down, false for a
+  // mouse up event.
+  onInteraction: PropTypes.func,
 };
 
 VtkRenderer.defaultProps = {


### PR DESCRIPTION
model.renderTopicSubscription requires a round trip to the server, and if the
view is destructed while the request in the flight, the frontend crashes.
